### PR TITLE
Fix drizzle-kit imports to use local path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+.pnpm-store

--- a/src/lib/services/config/configNode.server.ts
+++ b/src/lib/services/config/configNode.server.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
-import type { Config } from '@/lib/services/config/config';
+import type { Config } from './configTypes';
 import { parse } from 'toml';
-import { getDbUri } from '@/lib/services/config/dbUri.server';
+import { getDbUri } from './dbUri.server';
 
 const configFile = fs.readFileSync("./src/lib/server/config.toml", "utf8")
 const config: Config = parse(configFile);

--- a/src/lib/services/config/dbUri.server.ts
+++ b/src/lib/services/config/dbUri.server.ts
@@ -1,4 +1,4 @@
-import type { DbCreds } from '@/lib/services/config/config';
+import type { DbCreds } from './configTypes';
 
 export function getDbUri(creds: DbCreds) {
 	return `mysql://${creds.user}:${creds.password}@${creds.host}:${creds.port}/${creds.database}`;


### PR DESCRIPTION
Was having crashes from drizzle-kit being unable to resolve dependencies, fixed by making them relative imports