### PR TITLE
Refactor MobileMenu component structure and styles

### DIFF
--- a/src/components/menus/MobileMenu.svelte
+++ b/src/components/menus/MobileMenu.svelte
@@ -14,24 +14,26 @@
 >
 	<Drawer.Portal>
 		<Drawer.Content
-			class="after:h-0! duration-150! touch-auto! fixed z-10 w-full h-full overflow-y-scroll bottom-0 pointer-events-none"
-			style="{getOpenedMenu() === 'scout' ? 'height: fit-content !important;' : '' }"
+			class="after:h-0! duration-150! touch-auto! fixed z-10 w-full h-full overflow-y-scroll bottom-0 pointer-events-auto overscroll-contain"
+			style="{getOpenedMenu() === 'scout' ? 'height: fit-content !important;' : '' }; -webkit-overflow-scrolling: touch; touch-action: pan-y;"
 		>
 			<div
-				class="pb-20 px-2 pt-2 mt-40 min-h-full rounded-t-xl border border-t-border bg-card/60 backdrop-blur-sm pointer-events-auto"
-				out:slide={{ duration: 70, axis: "y" }}
+				class="pb-20 px-2 pt-2 mt-40 min-h-full rounded-t-xl border border-t-border bg-card/60 backdrop-blur-sm"
+				out:slide={{ duration: 70, axis: 'y' }}
 			>
-				<div class="w-full py-1 sticky top-2 flex items-center justify-between z-10 bg-card/60 backdrop-blur-sm rounded-lg border border-border">
-					<Drawer.Title
-						level="h1"
-						class="font-bold text-base tracking-tight mx-4"
-					>
-						{m["nav_" + getOpenedMenu()]()}
-					</Drawer.Title>
-					<CloseButton
-						onclick={() => openMenu(null)}
-						class="mr-1 hover:bg-accent/90! active:bg-accent/90!"
-					/>
+				<div class="sticky top-2 z-20">
+					<div class="w-full py-1 flex items-center justify-between bg-card/60 backdrop-blur-sm rounded-lg border border-border">
+						<Drawer.Title
+							level="h1"
+							class="font-bold text-base tracking-tight mx-4"
+						>
+							{m['nav_' + getOpenedMenu()]()}
+						</Drawer.Title>
+						<CloseButton
+							onclick={() => openMenu(null)}
+							class="mr-1 hover:bg-accent/90! active:bg-accent/90!"
+						/>
+					</div>
 				</div>
 
 				<MenuContainer />
@@ -39,5 +41,3 @@
 		</Drawer.Content>
 	</Drawer.Portal>
 </Drawer.Root>
-
-


### PR DESCRIPTION
Fix drawer scrolling in WebKit based browsers by enabling pointer events on the scroll container, adding WebKit specific scrolling hints (though at this point I'm not , and working around a sticky + backdrop-filter rendering issue. 

Tested on Safari and with Edge dev tools mimicking mobile size for a non-webkit experience - could do with real testing on actual android browsers.