### PR TITLE
fix(ui): login button missing when authRequired and customHome=false

### DIFF
--- a/src/components/ui/ErrorPage.svelte
+++ b/src/components/ui/ErrorPage.svelte
@@ -35,8 +35,8 @@
 			</p>
 		{/if}
 
-		{#if href && linkLabel}
-			<div class="mt-4 flex justify-center w-full gap-2">
+		<div class="mt-4 flex justify-center w-full gap-2">
+			{#if href && linkLabel}
 				<Button
 					variant={extraButtons ? "secondary" : "default"}
 					tag="a"
@@ -44,13 +44,9 @@
 				>
 					{linkLabel}
 				</Button>
-				{@render extraButtons?.()}
-			</div>
-		{:else if extraButtons}
-			<div class="mt-4 flex justify-center w-full gap-2">
-				{@render extraButtons?.()}
-			</div>
-		{/if}
+			{/if}
+			{@render extraButtons?.()}
+		</div>
 	</Card>
 </div>
 


### PR DESCRIPTION
Render the login button on the error page even when no back-link is present.