### PR TITLE
fix: bail loadKojiGeofences on non-ok response

### DIFF
--- a/src/lib/features/koji.ts
+++ b/src/lib/features/koji.ts
@@ -22,6 +22,7 @@ export async function loadKojiGeofences() {
 	const result = await fetch("/api/koji");
 
 	if (!result.ok) {
+		// this also errors when koji is disabled by admin, but checking isSupportedFeature would race on initial loading
 		console.error("Error while fetching geofences");
 		return;
 	}

--- a/src/lib/features/koji.ts
+++ b/src/lib/features/koji.ts
@@ -23,6 +23,7 @@ export async function loadKojiGeofences() {
 
 	if (!result.ok) {
 		console.error("Error while fetching geofences");
+		return;
 	}
 
 	const data: KojiFeatures = await result.json();


### PR DESCRIPTION
Avoids `forEach is not a function` when Koji is disabled and `/api/koji` returns 500.