### PR TITLE
feat: finer permissions

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -63,7 +63,20 @@ serverId = "1359028304128245934"
 #
 # Allows access to:
 #   - areas:    name[]    (area name, as configured in koji)
-#   - features: feature[] (*, pokemon, gym, pokestop, station, weather, s2cell, scout)
+#   - features: feature[] (* for anything, or a feature key from the list below)
+#
+# Feature keys. A key ending in `*` is a wildcard that grants everything nested below it;
+# you can also grant the individual sub-features instead. The full hierarchy:
+#
+# * (everything)
+#   map_object* (every map object)
+#     pokemon* / pokemon (no iv/pvp/cp/level), pokemon_iv, pokemon_pvp (full: iv + pvp)
+#     pokestop* / pokestop, quest, invasion, lure, contest, kecleon, golden_pokestop
+#     gym* / gym, raid
+#     station* / station, max_battle
+#     minor_map_object* (map objects with no sub-features) / nest, tappable, s2cell, spawnpoint, route
+#   tool* / scout, coverage_map, wayfarer_map
+#   ui* / search, weather
 #
 # Below are some examples
 
@@ -72,23 +85,23 @@ serverId = "1359028304128245934"
 everyone = true
 features = ["*"]
 
-# Every user gets access to gyms and pokestops in New York
+# Every user gets access to gyms (incl. raids) and pokestops (incl quests, lures, etc) in New York
 #[[server.permissions]]
 #everyone = true
 #areas = ["New York"]
-#features = ["gym", "pokestop"]
+#features = ["gym*", "pokestop*"]
 
-# Every logged-in user gets access to all Power Spots
+# Every logged-in user gets access to basic Power Spots
 # Above permissions are also granted, since these users also fulfill those requirements
 #[[server.permissions]]
 #loggedIn = true
 #features = ["station"]
 
-# Every user who's a member of my Malte# server gets access to all Pokemon and Scout
+# Every user who's a member of my Malte# server gets access to Pokemon (with IV, but no PVP) and Scout
 # Above permissions are also granted, since these users also fulfill those requirements
 #[[server.permissions]]
 #guildId = "1359028304128245934"
-#features = ["pokemon", "scout"]
+#features = ["pokemon_iv", "scout"]
 
 # Every user with that specific role gets access to every feature in Tokyo
 # Above permissions are also granted, since these users also fulfill those requirements

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -163,7 +163,7 @@ Permission rules are an array of sets:
 # guildId = "123..."
 # roleId = "123..."
 # areas = ["London"]
-features = ["gym", "pokestop"]
+features = ["gym*", "quest"]
 ```
 
 Rules are additive. For every rule a user matches, they get access to all its areas and features. `config.example.toml` shows some examples.
@@ -180,10 +180,36 @@ Grant fields:
 - `areas`: Koji area names (optional)
 - `features`: one or more feature keys
 
-Supported feature keys include:
+Feature keys are granular. The bare family keys are the **narrow** grant; the `*`-suffixed
+key grants the whole family, and `*` grants everything. Umbrella wildcards group several
+features together (e.g. `map_object*`, `tool*`). Data you are not permitted to see is never
+sent by the server, and features you cannot access are hidden in the UI (including the search
+index and the search box itself).
 
-- `*` for everything
-- `pokemon`, `pokestop`, `gym`, `station`, `nest`, `spawnpoint`, `route`, `tappable`, `s2cell`, `weather`, `scout`
+:::caution[Breaking change]
+`pokemon`, `pokestop`, `gym`, and `station` previously granted the **entire** family. They
+now grant only the narrow subset (basic pokemon / plain pokestop / plain gym / plain station).
+Use the `*`-suffixed wildcard (`pokemon*`, `pokestop*`, `gym*`, `station*`) to restore the old
+"whole family" behaviour. Configs using `*` are unaffected.
+:::
+
+Supported feature keys:
+
+- `*` — everything
+- **Pokemon:** `pokemon` (basic — no iv/pvp/cp/level), `pokemon_iv` (iv/cp/level), `pokemon_pvp` (full — iv + pvp), `pokemon*`
+- **Pokestops:** `pokestop` (plain), `quest`, `invasion`, `lure`, `contest`, `kecleon`, `golden_pokestop`, `pokestop*`
+- **Gyms:** `gym` (plain), `raid`, `gym*`
+- **Stations:** `station` (plain), `max_battle`, `station*`
+- **Other map objects:** `nest`, `tappable`, `s2cell`, `spawnpoint`, `route`
+- **Tools:** `scout`, `coverage_map`, `wayfarer_map`
+- **UI:** `search`, `weather`
+
+Umbrella wildcards bundle several of the above:
+
+- `map_object*` — every map object (`pokemon*`, `pokestop*`, `gym*`, `station*` and all minor map objects)
+- `minor_map_object*` — map objects with no sub-features (`nest`, `tappable`, `s2cell`, `spawnpoint`, `route`)
+- `tool*` — `scout`, `coverage_map`, `wayfarer_map`
+- `ui*` — `search`, `weather`
 
 ## `server.limits`
 

--- a/src/components/menus/filters/FilterSection.svelte
+++ b/src/components/menus/filters/FilterSection.svelte
@@ -11,7 +11,7 @@
 
 	import { untrack } from "svelte";
 	import { slide } from "svelte/transition";
-	import { hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
+	import { hasAnyFeatureAnywhere, hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
 	import { getUserDetails } from "@/lib/services/user/userDetails.svelte";
 	import type { AnyFilter, FilterCategory } from "@/lib/features/filters/filters";
 	import Switch from "@/components/ui/input/Switch.svelte";
@@ -38,7 +38,7 @@
 		isFilterable = true,
 		subCategories = []
 	}: {
-		requiredPermission: FeaturesKey;
+		requiredPermission: FeaturesKey | FeaturesKey[];
 		title: string;
 		category: ParentCategory;
 		mapObject: MapObjectType;
@@ -47,10 +47,16 @@
 		subCategories?: {
 			title: string;
 			category: FilterCategory;
+			requiredPermission: FeaturesKey;
 			filterModal?: ModalType;
 			filterable?: boolean;
 		}[];
 	} = $props();
+
+	const sectionFeatures = $derived([
+		...(Array.isArray(requiredPermission) ? requiredPermission : [requiredPermission]),
+		...subCategories.map((subcategory) => subcategory.requiredPermission)
+	]);
 
 	let subcategoriesExpanded: boolean = $state(
 		untrack(() => sessionExpandedState[category as string] ?? false)
@@ -79,8 +85,6 @@
 			value ||
 			!Object.values(getUserSettings().filters[category]).find((subcategory) => subcategory.enabled)
 		) {
-			// if enabled, always enable parent
-			// if all siblngs are disabled, disable parent
 			getUserSettings().filters[category].enabled = value;
 		}
 
@@ -90,7 +94,7 @@
 	}
 </script>
 
-{#if hasFeatureAnywhere(getUserDetails().permissions, requiredPermission)}
+{#if hasAnyFeatureAnywhere(getUserDetails().permissions, sectionFeatures)}
 	<Card class="py-1 px-2">
 		<FilterControl
 			{title}
@@ -108,17 +112,19 @@
 		{#if subCategories.length > 0}
 			{#if subcategoriesExpanded}
 				<div class="mb-2" transition:slide={{ duration: 80 }}>
-					{#each subCategories as subcategory}
-						<FilterControl
-							{mapObject}
-							title={subcategory.title}
-							majorCategory={category}
-							subCategory={subcategory.category}
-							filterModal={subcategory.filterModal}
-							isFilterable={subcategory.filterable ?? true}
-							onEnabledChange={onSubEnabledChange}
-							filter={getUserSettings().filters[category][subcategory.category]}
-						/>
+					{#each subCategories as subcategory (subcategory.category)}
+						{#if hasFeatureAnywhere(getUserDetails().permissions, subcategory.requiredPermission)}
+							<FilterControl
+								{mapObject}
+								title={subcategory.title}
+								majorCategory={category}
+								subCategory={subcategory.category}
+								filterModal={subcategory.filterModal}
+								isFilterable={subcategory.filterable ?? true}
+								onEnabledChange={onSubEnabledChange}
+								filter={getUserSettings().filters[category][subcategory.category]}
+							/>
+						{/if}
 					{/each}
 				</div>
 			{/if}

--- a/src/components/menus/filters/FiltersMenu.svelte
+++ b/src/components/menus/filters/FiltersMenu.svelte
@@ -4,7 +4,7 @@
 	import FilterSection from "@/components/menus/filters/FilterSection.svelte";
 	import SignInButton from "@/components/ui/user/SignInButton.svelte";
 	import { MapObjectType } from "@/lib/mapObjects/mapObjectTypes";
-	import { Features } from "@/lib/utils/features";
+	import { featureFamily, Features } from "@/lib/utils/features";
 </script>
 
 <div
@@ -13,7 +13,7 @@
 >
 	<SignInButton />
 	<FilterSection
-		requiredPermission="pokemon"
+		requiredPermission={featureFamily[MapObjectType.POKEMON]}
 		title={m.pogo_pokemon()}
 		category="pokemon"
 		mapObject={MapObjectType.POKEMON}
@@ -21,43 +21,93 @@
 	/>
 
 	<FilterSection
-		requiredPermission="pokestop"
+		requiredPermission={Features.POKESTOP}
 		title={m.pogo_pokestops()}
 		category="pokestop"
 		mapObject={MapObjectType.POKESTOP}
 		isFilterable={false}
 		subCategories={[
-			{ title: m.plain_pokestops(), category: "pokestopPlain", filterable: false },
-			{ title: m.pogo_quests(), category: "quest", filterModal: "filtersetQuest" },
-			{ title: m.pogo_invasion(), category: "invasion", filterModal: "filtersetInvasion" },
-			{ title: m.lures(), category: "lure", filterable: false },
-			{ title: m.contests(), category: "contest", filterable: false },
-			{ title: m.kecleon(), category: "kecleon", filterable: false },
-			{ title: m.golden_pokestops(), category: "goldPokestop", filterable: false }
+			{
+				title: m.plain_pokestops(),
+				category: "pokestopPlain",
+				requiredPermission: Features.POKESTOP,
+				filterable: false
+			},
+			{
+				title: m.pogo_quests(),
+				category: "quest",
+				requiredPermission: Features.QUEST,
+				filterModal: "filtersetQuest"
+			},
+			{
+				title: m.pogo_invasion(),
+				category: "invasion",
+				requiredPermission: Features.INVASION,
+				filterModal: "filtersetInvasion"
+			},
+			{ title: m.lures(), category: "lure", requiredPermission: Features.LURE, filterable: false },
+			{
+				title: m.contests(),
+				category: "contest",
+				requiredPermission: Features.CONTEST,
+				filterable: false
+			},
+			{
+				title: m.kecleon(),
+				category: "kecleon",
+				requiredPermission: Features.KECLEON,
+				filterable: false
+			},
+			{
+				title: m.golden_pokestops(),
+				category: "goldPokestop",
+				requiredPermission: Features.GOLDEN_POKESTOP,
+				filterable: false
+			}
 		]}
 	/>
 
 	<FilterSection
-		requiredPermission={MapObjectType.GYM}
+		requiredPermission={Features.GYM}
 		title={m.pogo_gyms()}
 		category="gym"
 		mapObject={MapObjectType.GYM}
 		isFilterable={false}
 		subCategories={[
-			{ title: m.plain_gyms(), category: "gymPlain", filterable: false },
-			{ title: m.raids(), category: "raid", filterModal: "filtersetRaid" }
+			{
+				title: m.plain_gyms(),
+				category: "gymPlain",
+				requiredPermission: Features.GYM,
+				filterable: false
+			},
+			{
+				title: m.raids(),
+				category: "raid",
+				requiredPermission: Features.RAID,
+				filterModal: "filtersetRaid"
+			}
 		]}
 	/>
 
 	<FilterSection
-		requiredPermission={MapObjectType.STATION}
+		requiredPermission={Features.STATION}
 		title={m.pogo_stations()}
 		category={MapObjectType.STATION}
 		mapObject={MapObjectType.STATION}
 		isFilterable={false}
 		subCategories={[
-			{ title: m.plain_stations(), category: "stationPlain", filterable: false },
-			{ title: m.max_battles(), category: "maxBattle", filterModal: "filtersetMaxBattle" }
+			{
+				title: m.plain_stations(),
+				category: "stationPlain",
+				requiredPermission: Features.STATION,
+				filterable: false
+			},
+			{
+				title: m.max_battles(),
+				category: "maxBattle",
+				requiredPermission: Features.MAX_BATTLE,
+				filterModal: "filtersetMaxBattle"
+			}
 		]}
 	/>
 

--- a/src/components/menus/filters/filterset/PageNewFilterset.svelte
+++ b/src/components/menus/filters/filterset/PageNewFilterset.svelte
@@ -8,17 +8,18 @@
 		getFiltersetPageTransition
 	} from "@/lib/features/filters/filtersetPages.svelte.js";
 	import {
-		type SelectedFiltersetData,
 		setCurrentSelectedFilterset
 	} from "@/lib/features/filters/filtersetPageData.svelte.js";
 	import { filterTitle } from "@/lib/features/filters/filtersetUtils.svelte";
 	import FiltersetIcon from "@/lib/features/filters/FiltersetIcon.svelte";
 	import Separator from "@/components/ui/Separator.svelte";
-	import {
-		getPremadeFiltersets,
-		premadeFiltersets
-	} from "@/lib/features/filters/premadeFiltersets";
+	import { getPremadeFiltersets } from "@/lib/features/filters/premadeFiltersets";
 	import type { FilterCategory } from "@/lib/features/filters/filters";
+	import type { AnyFilterset, FiltersetPokemon } from "@/lib/features/filters/filtersets";
+	import { pokemonFiltersetRequiredFeature } from "@/lib/features/filters/filterUtilsPokemon";
+	import { hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
+	import { getUserDetails } from "@/lib/services/user/userDetails.svelte";
+	import { Features } from "@/lib/utils/features";
 	import { getId } from "@/lib/utils/uuid";
 	import { m } from "@/lib/paraglide/messages";
 
@@ -26,14 +27,22 @@
 		majorCategory,
 		subCategory = undefined
 	}: {
-		majorCategory: SelectedFiltersetData["majorCategory"];
+		majorCategory: FilterCategory;
 		subCategory?: FilterCategory;
 	} = $props();
 
-	// @ts-ignore
-	let premades = $derived(
-		getPremadeFiltersets(majorCategory) ?? getPremadeFiltersets(subCategory) ?? []
+	function isPremadePermitted(filterset: AnyFilterset): boolean {
+		if (majorCategory !== "pokemon" && subCategory !== "pokemon") return true;
+
+		const required = pokemonFiltersetRequiredFeature(filterset as FiltersetPokemon);
+		if (required === Features.POKEMON) return true;
+		return hasFeatureAnywhere(getUserDetails().permissions, required);
+	}
+
+	let allPremades = $derived(
+		getPremadeFiltersets(majorCategory) ?? (subCategory ? getPremadeFiltersets(subCategory) : []) ?? []
 	);
+	let premades = $derived(allPremades.filter(isPremadePermitted));
 </script>
 
 <div in:fly={getFiltersetPageTransition().in} out:fly={getFiltersetPageTransition().out}>
@@ -48,7 +57,7 @@
 
 	<div class="-mx-4 px-4">
 		<div class="flex flex-col gap-1">
-			{#each premades as filterset}
+			{#each premades as filterset (filterset.id)}
 				<Button
 					class="w-full flex gap-2 items-center justify-start rounded-md py-2 h-12 m-0! pl-4 pr-2"
 					size=""

--- a/src/components/menus/filters/filterset/pokemon/AppearanceAttribute.svelte
+++ b/src/components/menus/filters/filterset/pokemon/AppearanceAttribute.svelte
@@ -10,27 +10,31 @@
 
 	let {
 		data,
-		sizeBounds
+		sizeBounds,
+		showSize = true
 	}: {
 		data: FiltersetPokemon;
 		sizeBounds: MinMax;
+		showSize?: boolean;
 	} = $props();
 
 	let thisValues = $derived(data.gender?.map(String) ?? ["1", "2", "3"]);
 </script>
 
-<SliderRange
-	min={sizeBounds.min}
-	max={sizeBounds.max}
-	title={m.pokemon_size()}
-	valueMin={data.size?.min ?? sizeBounds.min}
-	valueMax={data.size?.max ?? sizeBounds.max}
-	onchange={([min, max]) =>
-		changeAttributeMinMax(data, "size", sizeBounds.min, sizeBounds.max, min, max)}
-	labels={pokemonSizes}
-/>
+{#if showSize}
+	<SliderRange
+		min={sizeBounds.min}
+		max={sizeBounds.max}
+		title={m.pokemon_size()}
+		valueMin={data.size?.min ?? sizeBounds.min}
+		valueMax={data.size?.max ?? sizeBounds.max}
+		onchange={([min, max]) =>
+			changeAttributeMinMax(data, "size", sizeBounds.min, sizeBounds.max, min, max)}
+		labels={pokemonSizes}
+	/>
+{/if}
 
-<div class="mt-4">
+<div class:mt-4={showSize}>
 	<div class="text-base font-semibold mb-2">
 		{m.pokemon_gender()}
 	</div>

--- a/src/components/menus/filters/filterset/pokemon/AppearanceChips.svelte
+++ b/src/components/menus/filters/filterset/pokemon/AppearanceChips.svelte
@@ -7,14 +7,16 @@
 
 	let {
 		data,
-		sizeBounds
+		sizeBounds,
+		showSize = true
 	}: {
 		data: FiltersetPokemon;
 		sizeBounds: MinMax;
+		showSize?: boolean;
 	} = $props();
 </script>
 
-{#if data.size}
+{#if showSize && data.size}
 	<AttributeChip
 		label={getAttributeLabelSize(data.size)}
 		isEmpty={false}
@@ -34,6 +36,6 @@
 		}}
 	/>
 {/each}
-{#if !data.size && !data.gender}
+{#if !(showSize && data.size) && !data.gender}
 	<AttributeChip isEmpty={true} />
 {/if}

--- a/src/components/menus/filters/filterset/pokemon/PokemonFilterset.svelte
+++ b/src/components/menus/filters/filterset/pokemon/PokemonFilterset.svelte
@@ -23,10 +23,16 @@
 	import { MapObjectType } from "@/lib/mapObjects/mapObjectTypes";
 	import PokemonSelectPage from "@/components/menus/filters/filterset/multiselect/PokemonSelectPage.svelte";
 	import { getSpawnablePokemon } from "@/lib/features/masterStats.svelte";
+	import { hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
+	import { getUserDetails } from "@/lib/services/user/userDetails.svelte";
+	import { Features } from "@/lib/utils/features";
 
 	let data: FiltersetPokemon | undefined = $derived(getCurrentSelectedFilterset()?.data) as
 		| FiltersetPokemon
 		| undefined;
+
+	let canIv = $derived(hasFeatureAnywhere(getUserDetails().permissions, Features.POKEMON_IV));
+	let canPvp = $derived(hasFeatureAnywhere(getUserDetails().permissions, Features.POKEMON_PVP));
 </script>
 
 <FiltersetModal
@@ -62,152 +68,156 @@
 					{/snippet}
 				</Attribute>
 				<Attribute label={m.pokemon_looks()}>
-					<AppearanceChips {data} sizeBounds={pokemonBounds.size} />
+					<AppearanceChips {data} sizeBounds={pokemonBounds.size} showSize={canIv} />
 					{#snippet page(thisData: FiltersetPokemon)}
-						<AppearanceAttribute data={thisData} sizeBounds={pokemonBounds.size} />
+						<AppearanceAttribute data={thisData} sizeBounds={pokemonBounds.size} showSize={canIv} />
 					{/snippet}
 				</Attribute>
 			</AttributesOverview>
-			<AttributesOverview>
-				<Attribute label={m.pogo_ivs()}>
-					<IvChips {data} ivBounds={pokemonBounds.iv} percBounds={pokemonBounds.ivProduct} />
-					{#snippet page(thisData: FiltersetPokemon)}
-						<IvAttribute
-							data={thisData}
-							ivBounds={pokemonBounds.iv}
-							percBounds={pokemonBounds.ivProduct}
+			{#if canIv}
+				<AttributesOverview>
+					<Attribute label={m.pogo_ivs()}>
+						<IvChips {data} ivBounds={pokemonBounds.iv} percBounds={pokemonBounds.ivProduct} />
+						{#snippet page(thisData: FiltersetPokemon)}
+							<IvAttribute
+								data={thisData}
+								ivBounds={pokemonBounds.iv}
+								percBounds={pokemonBounds.ivProduct}
+							/>
+						{/snippet}
+					</Attribute>
+					<Attribute label={m.cp()}>
+						<AttributeChip
+							label={getAttributeLabelCp(data?.cp)}
+							isEmpty={!data.cp}
+							onremove={() => delete data.cp}
 						/>
-					{/snippet}
-				</Attribute>
-				<Attribute label={m.cp()}>
-					<AttributeChip
-						label={getAttributeLabelCp(data?.cp)}
-						isEmpty={!data.cp}
-						onremove={() => delete data.cp}
-					/>
-					{#snippet page(thisData: FiltersetPokemon)}
-						<SliderRange
-							min={pokemonBounds.cp.min}
-							max={pokemonBounds.cp.max}
-							title={m.cp()}
-							valueMin={thisData.cp?.min ?? pokemonBounds.cp.min}
-							valueMax={thisData.cp?.max ?? pokemonBounds.cp.max}
-							onchange={([min, max]) =>
-								changeAttributeMinMax(
-									thisData,
-									"cp",
-									pokemonBounds.cp.min,
-									pokemonBounds.cp.max,
-									min,
-									max
-								)}
+						{#snippet page(thisData: FiltersetPokemon)}
+							<SliderRange
+								min={pokemonBounds.cp.min}
+								max={pokemonBounds.cp.max}
+								title={m.cp()}
+								valueMin={thisData.cp?.min ?? pokemonBounds.cp.min}
+								valueMax={thisData.cp?.max ?? pokemonBounds.cp.max}
+								onchange={([min, max]) =>
+									changeAttributeMinMax(
+										thisData,
+										"cp",
+										pokemonBounds.cp.min,
+										pokemonBounds.cp.max,
+										min,
+										max
+									)}
+							/>
+						{/snippet}
+					</Attribute>
+					<Attribute label={m.level()}>
+						<AttributeChip
+							label={getAttributeLabelLevel(data?.level)}
+							isEmpty={!data.level}
+							onremove={() => delete data.level}
 						/>
-					{/snippet}
-				</Attribute>
-				<Attribute label={m.level()}>
-					<AttributeChip
-						label={getAttributeLabelLevel(data?.level)}
-						isEmpty={!data.level}
-						onremove={() => delete data.level}
-					/>
-					{#snippet page(thisData: FiltersetPokemon)}
-						<SliderRange
-							min={pokemonBounds.level.min}
-							max={pokemonBounds.level.max}
-							title={m.level()}
-							valueMin={thisData.level?.min ?? pokemonBounds.level.min}
-							valueMax={thisData.level?.max ?? pokemonBounds.level.max}
-							onchange={([min, max]) =>
-								changeAttributeMinMax(
-									thisData,
-									"level",
-									pokemonBounds.level.min,
-									pokemonBounds.level.max,
-									min,
-									max
-								)}
-						/>
-					{/snippet}
-				</Attribute>
-			</AttributesOverview>
+						{#snippet page(thisData: FiltersetPokemon)}
+							<SliderRange
+								min={pokemonBounds.level.min}
+								max={pokemonBounds.level.max}
+								title={m.level()}
+								valueMin={thisData.level?.min ?? pokemonBounds.level.min}
+								valueMax={thisData.level?.max ?? pokemonBounds.level.max}
+								onchange={([min, max]) =>
+									changeAttributeMinMax(
+										thisData,
+										"level",
+										pokemonBounds.level.min,
+										pokemonBounds.level.max,
+										min,
+										max
+									)}
+							/>
+						{/snippet}
+					</Attribute>
+				</AttributesOverview>
+			{/if}
 
-			<AttributesOverview>
-				<Attribute label={m.little_league()}>
-					<AttributeChip
-						label={getAttributeLabelRank(data?.pvpRankLittle)}
-						isEmpty={!data.pvpRankLittle}
-						onremove={() => delete data.pvpRankLittle}
-					/>
-					{#snippet page(thisData: FiltersetPokemon)}
-						<SliderRange
-							min={pokemonBounds.rank.min}
-							max={pokemonBounds.rank.max}
-							title={m.little_league_rank()}
-							valueMin={thisData.pvpRankLittle?.min ?? pokemonBounds.rank.min}
-							valueMax={thisData.pvpRankLittle?.max ?? pokemonBounds.rank.max}
-							onchange={([min, max]) =>
-								changeAttributeMinMax(
-									thisData,
-									"pvpRankLittle",
-									pokemonBounds.rank.min,
-									pokemonBounds.rank.max,
-									min,
-									max
-								)}
+			{#if canPvp}
+				<AttributesOverview>
+					<Attribute label={m.little_league()}>
+						<AttributeChip
+							label={getAttributeLabelRank(data?.pvpRankLittle)}
+							isEmpty={!data.pvpRankLittle}
+							onremove={() => delete data.pvpRankLittle}
 						/>
-					{/snippet}
-				</Attribute>
-				<Attribute label={m.great_league()}>
-					<AttributeChip
-						label={getAttributeLabelRank(data?.pvpRankGreat)}
-						isEmpty={!data.pvpRankGreat}
-						onremove={() => delete data.pvpRankGreat}
-					/>
-					{#snippet page(thisData: FiltersetPokemon)}
-						<SliderRange
-							min={pokemonBounds.rank.min}
-							max={pokemonBounds.rank.max}
-							title={m.great_league_rank()}
-							valueMin={thisData.pvpRankGreat?.min ?? pokemonBounds.rank.min}
-							valueMax={thisData.pvpRankGreat?.max ?? pokemonBounds.rank.max}
-							onchange={([min, max]) =>
-								changeAttributeMinMax(
-									thisData,
-									"pvpRankGreat",
-									pokemonBounds.rank.min,
-									pokemonBounds.rank.max,
-									min,
-									max
-								)}
+						{#snippet page(thisData: FiltersetPokemon)}
+							<SliderRange
+								min={pokemonBounds.rank.min}
+								max={pokemonBounds.rank.max}
+								title={m.little_league_rank()}
+								valueMin={thisData.pvpRankLittle?.min ?? pokemonBounds.rank.min}
+								valueMax={thisData.pvpRankLittle?.max ?? pokemonBounds.rank.max}
+								onchange={([min, max]) =>
+									changeAttributeMinMax(
+										thisData,
+										"pvpRankLittle",
+										pokemonBounds.rank.min,
+										pokemonBounds.rank.max,
+										min,
+										max
+									)}
+							/>
+						{/snippet}
+					</Attribute>
+					<Attribute label={m.great_league()}>
+						<AttributeChip
+							label={getAttributeLabelRank(data?.pvpRankGreat)}
+							isEmpty={!data.pvpRankGreat}
+							onremove={() => delete data.pvpRankGreat}
 						/>
-					{/snippet}
-				</Attribute>
-				<Attribute label={m.ultra_league()}>
-					<AttributeChip
-						label={getAttributeLabelRank(data?.pvpRankUltra)}
-						isEmpty={!data.pvpRankUltra}
-						onremove={() => delete data.pvpRankUltra}
-					/>
-					{#snippet page(thisData: FiltersetPokemon)}
-						<SliderRange
-							min={pokemonBounds.rank.min}
-							max={pokemonBounds.rank.max}
-							title={m.ultra_league_rank()}
-							valueMin={thisData.pvpRankUltra?.min ?? pokemonBounds.rank.min}
-							valueMax={thisData.pvpRankUltra?.max ?? pokemonBounds.rank.max}
-							onchange={([min, max]) =>
-								changeAttributeMinMax(
-									thisData,
-									"pvpRankUltra",
-									pokemonBounds.rank.min,
-									pokemonBounds.rank.max,
-									min,
-									max
-								)}
+						{#snippet page(thisData: FiltersetPokemon)}
+							<SliderRange
+								min={pokemonBounds.rank.min}
+								max={pokemonBounds.rank.max}
+								title={m.great_league_rank()}
+								valueMin={thisData.pvpRankGreat?.min ?? pokemonBounds.rank.min}
+								valueMax={thisData.pvpRankGreat?.max ?? pokemonBounds.rank.max}
+								onchange={([min, max]) =>
+									changeAttributeMinMax(
+										thisData,
+										"pvpRankGreat",
+										pokemonBounds.rank.min,
+										pokemonBounds.rank.max,
+										min,
+										max
+									)}
+							/>
+						{/snippet}
+					</Attribute>
+					<Attribute label={m.ultra_league()}>
+						<AttributeChip
+							label={getAttributeLabelRank(data?.pvpRankUltra)}
+							isEmpty={!data.pvpRankUltra}
+							onremove={() => delete data.pvpRankUltra}
 						/>
-					{/snippet}
-				</Attribute>
-			</AttributesOverview>
+						{#snippet page(thisData: FiltersetPokemon)}
+							<SliderRange
+								min={pokemonBounds.rank.min}
+								max={pokemonBounds.rank.max}
+								title={m.ultra_league_rank()}
+								valueMin={thisData.pvpRankUltra?.min ?? pokemonBounds.rank.min}
+								valueMax={thisData.pvpRankUltra?.max ?? pokemonBounds.rank.max}
+								onchange={([min, max]) =>
+									changeAttributeMinMax(
+										thisData,
+										"pvpRankUltra",
+										pokemonBounds.rank.min,
+										pokemonBounds.rank.max,
+										min,
+										max
+									)}
+							/>
+						{/snippet}
+					</Attribute>
+				</AttributesOverview>
+			{/if}
 		{/if}
 	{/snippet}
 </FiltersetModal>

--- a/src/components/menus/tools/ToolsMenu.svelte
+++ b/src/components/menus/tools/ToolsMenu.svelte
@@ -1,27 +1,17 @@
 <script lang="ts">
-	import { Binoculars, ChartColumnBig, Earth, MapPin } from "lucide-svelte";
-	import { FillLayer, GeoJSON, LineLayer, MapLibre } from "svelte-maplibre";
-	import { getDefaultMapStyle } from "@/lib/services/themeMode";
-	import { CoverageMapLayerId, MapObjectLayerId, MapSourceId } from "@/lib/map/layers";
+	import { Binoculars, Earth, MapPin } from "lucide-svelte";
 	import ToolLink from "@/components/menus/tools/ToolLink.svelte";
-	import { getCoverageMapAreas, openCoverageMap } from "@/lib/features/coverageMap.svelte";
+	import { openCoverageMap } from "@/lib/features/coverageMap.svelte";
 	import { openWayfarerMap } from "@/lib/features/wayfarerMap.svelte";
-	import GeometryLayer from "@/components/map/GeometryLayer.svelte";
 	import { getConfig } from "@/lib/services/config/config";
 	import { hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
 	import { getUserDetails } from "@/lib/services/user/userDetails.svelte";
 	import { Features } from "@/lib/utils/features";
 	import { isSupportedFeature } from "@/lib/services/supportedFeatures";
-	import {
-		getCoords,
-		getScoutGeojsons,
-		setCurrentScoutCenter,
-		setCurrentScoutCoords
-	} from "@/lib/features/scout.svelte";
+	import { setCurrentScoutCenter, setCurrentScoutCoords } from "@/lib/features/scout.svelte";
 	import { Menu, openMenu, setJustChangedMenus } from "@/lib/ui/menus.svelte";
 	import { getMap } from "@/lib/map/map.svelte";
 	import { Coords } from "@/lib/utils/coordinates";
-	import { featureCollection } from "@turf/turf";
 	import * as m from "@/lib/paraglide/messages";
 </script>
 
@@ -39,111 +29,24 @@
 				setCurrentScoutCenter(Coords.infer(map.getCenter()));
 				openMenu(Menu.SCOUT);
 			}}
-		>
-			<!--{@const coords = getCoords(-->
-			<!--	new Coords(-->
-			<!--		(getConfig().mapPositions.scoutLat ?? 53.563) - 0.01,-->
-			<!--		(getConfig().mapPositions.scoutLon ?? 9.979) + 0.04-->
-			<!--	),-->
-			<!--	2-->
-			<!--)}-->
-			<!--{@const [smallPoints, bigPoints] = getScoutGeojsons(coords, 2)}-->
-			<!--<MapLibre-->
-			<!--	class="absolute! top-0 right-0 h-full w-1/2"-->
-			<!--	center={[-->
-			<!--		getConfig().mapPositions.scoutLon ?? 9.979,-->
-			<!--		getConfig().mapPositions.scoutLat ?? 53.563-->
-			<!--	]}-->
-			<!--	zoom={getConfig().mapPositions.scoutZoom ?? 10.5}-->
-			<!--	filterLayers={(l) => l.type !== "symbol"}-->
-			<!--	style={getDefaultMapStyle().url}-->
-			<!--	attributionControl={false}-->
-			<!--	interactive={true}-->
-			<!--	zoomOnDoubleClick={false}-->
-			<!--&gt;-->
-			<!--	<GeoJSON id="scout-small" data={featureCollection(smallPoints)}>-->
-			<!--		<FillLayer-->
-			<!--			paint={{-->
-			<!--				"fill-color": ["get", "fillColor"],-->
-			<!--				"fill-opacity": 0.5-->
-			<!--			}}-->
-			<!--		/>-->
-			<!--		<LineLayer-->
-			<!--			layout={{ "line-cap": "round", "line-join": "round" }}-->
-			<!--			paint={{ "line-color": ["get", "strokeColor"], "line-width": 2 }}-->
-			<!--		/>-->
-			<!--	</GeoJSON>-->
-			<!--	<GeoJSON id="scout-big" data={featureCollection(bigPoints)}>-->
-			<!--		<FillLayer-->
-			<!--			paint={{-->
-			<!--				"fill-color": ["get", "fillColor"],-->
-			<!--				"fill-opacity": 0.5-->
-			<!--			}}-->
-			<!--		/>-->
-			<!--		<LineLayer-->
-			<!--			layout={{ "line-cap": "round", "line-join": "round" }}-->
-			<!--			paint={{ "line-color": ["get", "strokeColor"], "line-width": 2 }}-->
-			<!--		/>-->
-			<!--	</GeoJSON>-->
-			<!--</MapLibre>-->
-		</ToolLink>
+		/>
 	{/if}
 
-	{#if isSupportedFeature("koji") && getConfig().tools.coverageMap}
+	{#if isSupportedFeature("koji") && getConfig().tools.coverageMap && hasFeatureAnywhere(getUserDetails().permissions, Features.COVERAGE_MAP)}
 		<ToolLink
 			Icon={Earth}
 			title={m.tool_coverage_map_title()}
 			description={m.tool_coverage_map_description()}
 			onclick={() => openCoverageMap()}
-		>
-			<!--			<MapLibre-->
-			<!--				class="absolute! top-0 right-0 h-full w-1/2"-->
-			<!--				center={[-->
-			<!--					getConfig().mapPositions.coverageLon ?? 9.979,-->
-			<!--					getConfig().mapPositions.coverageLat ?? 53.563-->
-			<!--				]}-->
-			<!--				zoom={getConfig().mapPositions.coverageZoom ?? 5.5}-->
-			<!--				filterLayers={(l) => l.type !== "symbol"}-->
-			<!--				style={getDefaultMapStyle().url}-->
-			<!--				attributionControl={false}-->
-			<!--				interactive={false}-->
-			<!--				zoomOnDoubleClick={false}-->
-			<!--			>-->
-			<!--				<GeoJSON id="tools-coveragemap" data={getCoverageMapAreas()}>-->
-			<!--					<FillLayer-->
-			<!--						paint={{-->
-			<!--							"fill-color": ["get", "fillColor"],-->
-			<!--							"fill-opacity": 0.5-->
-			<!--						}}-->
-			<!--					/>-->
-			<!--					<LineLayer-->
-			<!--						layout={{ "line-cap": "round", "line-join": "round" }}-->
-			<!--						paint={{ "line-color": ["get", "strokeColor"], "line-width": 2 }}-->
-			<!--					/>-->
-			<!--				</GeoJSON>-->
-			<!--			</MapLibre>-->
-		</ToolLink>
+		/>
 	{/if}
 
-	<ToolLink
-		Icon={MapPin}
-		title={m.tool_wayfarer_title()}
-		description={m.tool_wayfarer_description()}
-		onclick={() => openWayfarerMap()}
-	>
-		<!--		<MapLibre-->
-		<!--			class="absolute! top-0 right-0 h-full w-1/2"-->
-		<!--			center={[-->
-		<!--				getConfig().general.defaultLon ?? 9.979,-->
-		<!--				getConfig().general.defaultLat ?? 53.563-->
-		<!--			]}-->
-		<!--			zoom={getConfig().general.defaultZoom ?? 5.5}-->
-		<!--			filterLayers={(l) => l.type !== "symbol"}-->
-		<!--			style={getDefaultMapStyle().url}-->
-		<!--			attributionControl={false}-->
-		<!--			interactive={false}-->
-		<!--			zoomOnDoubleClick={false}-->
-		<!--		>-->
-		<!--		</MapLibre>-->
-	</ToolLink>
+	{#if hasFeatureAnywhere(getUserDetails().permissions, Features.WAYFARER_MAP)}
+		<ToolLink
+			Icon={MapPin}
+			title={m.tool_wayfarer_title()}
+			description={m.tool_wayfarer_description()}
+			onclick={() => openWayfarerMap()}
+		/>
+	{/if}
 </div>

--- a/src/components/ui/fab/SearchFab.svelte
+++ b/src/components/ui/fab/SearchFab.svelte
@@ -16,6 +16,9 @@
 	import type maplibre from "maplibre-gl";
 	import { onShortcutSearch } from "@/lib/utils/keyboard";
 	import { onDestroy } from "svelte";
+	import { hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
+	import { getUserDetails } from "@/lib/services/user/userDetails.svelte";
+	import { Features } from "@/lib/utils/features";
 	import MainSearchResults from "@/components/ui/search/MainSearchResults.svelte";
 	import CoverageSearchResults from "@/components/ui/search/CoverageSearchResults.svelte";
 	import WayfarerSearchResults from "@/components/ui/search/WayfarerSearchResults.svelte";
@@ -81,7 +84,11 @@
 		}
 	});
 
-	let isSearchAllowed = $derived(!isSearchViewActive() && hasSearchData);
+	let hasSearchPermission = $derived(
+		searchMode !== "main" || hasFeatureAnywhere(getUserDetails().permissions, Features.SEARCH)
+	);
+
+	let isSearchAllowed = $derived(!isSearchViewActive() && hasSearchData && hasSearchPermission);
 	let searchInitialized: boolean = $state(false);
 
 	$effect(() => {

--- a/src/components/ui/popups/pokemon/PokemonPopup.svelte
+++ b/src/components/ui/popups/pokemon/PokemonPopup.svelte
@@ -60,6 +60,9 @@
 	import { MapObjectType } from "@/lib/mapObjects/mapObjectTypes";
 	import CompactPvpEntry from "./CompactPvpEntry.svelte";
 	import { useMetadata } from "@/lib/ui/metadata.svelte";
+	import { isPointInAllowedArea } from "@/lib/services/user/checkPerm";
+	import { getUserDetails } from "@/lib/services/user/userDetails.svelte";
+	import { Features } from "@/lib/utils/features";
 
 	let data: PokemonData = $derived(
 		(getMapObjects()[getCurrentSelectedMapId()] as PokemonData) ??
@@ -67,7 +70,10 @@
 	);
 	useMetadata(() => ({ title: data ? mPokemon(data) : undefined }));
 
-	// let masterPokemon: MasterPokemon | undefined = $derived(getMasterPokemon(data.pokemon_id))
+	let canSeeIv = $derived(
+		data &&
+			isPointInAllowedArea(getUserDetails().permissions, Features.POKEMON_IV, data.lat, data.lon)
+	);
 
 	let stats: PokemonStats | undefined = $derived(
 		getMasterPokemonStats(data.pokemon_id, data.form ?? 0)
@@ -132,20 +138,20 @@
 		</IconValue>
 	{/if}
 
-	{#if !data.iv && data.iv !== 0}
+	{#if canSeeIv && !data.iv && data.iv !== 0}
 		<IconValue Icon={SearchX}>
 			{m.popup_no_iv_scanned()}
 		</IconValue>
 	{/if}
 
-	{#if data.cp !== null || data.level !== null}
+	{#if data.cp != null || data.level != null}
 		<IconValue Icon={ChartSpline}>
-			{#if data.cp !== null}
+			{#if data.cp != null}
 				<span class="font-semibold">
 					{m.pogo_cp({ cp: data.cp })}
 				</span>
 			{/if}
-			{#if data.level !== null}
+			{#if data.level != null}
 				({m.pogo_level({ level: data.level })})
 			{/if}
 		</IconValue>
@@ -284,7 +290,7 @@
 			{/if}
 		</IconValue>
 
-		{#if data.gender !== null}
+		{#if data.gender != null}
 			{#if data.gender === 1}
 				<IconValue Icon={Mars}>
 					{m.pokemon_gender()}: <b>{m.pokemon_gender_male()}</b>
@@ -300,7 +306,7 @@
 			{/if}
 		{/if}
 
-		{#if data.size !== null}
+		{#if data.size != null}
 			<IconValue Icon={Ruler}>
 				<span>
 					Size: <b>{getPokemonSize(data.size)}</b>

--- a/src/lib/features/filters/filterUtilsPokemon.ts
+++ b/src/lib/features/filters/filterUtilsPokemon.ts
@@ -5,6 +5,14 @@ import { makeAttributeRangeLabel } from "@/lib/features/filters/makeAttributeChi
 import * as m from "@/lib/paraglide/messages";
 import { mPokemon } from "@/lib/services/ingameLocale";
 import { getPokemonSize, League } from "@/lib/utils/pokemonUtils";
+import { Features, type FeaturesKey } from "@/lib/utils/features";
+
+export function pokemonFiltersetRequiredFeature(fs: FiltersetPokemon): FeaturesKey {
+	if (fs.pvpRankLittle || fs.pvpRankGreat || fs.pvpRankUltra) return Features.POKEMON_PVP;
+	if (fs.iv || fs.cp || fs.ivAtk || fs.ivDef || fs.ivSta || fs.level || fs.size)
+		return Features.POKEMON_IV;
+	return Features.POKEMON;
+}
 
 export const pokemonBounds = {
 	ivProduct: {

--- a/src/lib/mapObjects/updateMapObject.ts
+++ b/src/lib/mapObjects/updateMapObject.ts
@@ -12,8 +12,9 @@ import { allMapObjectTypes, type MapData, MapObjectType } from "@/lib/mapObjects
 import { getS2CellMapObjects } from "@/lib/mapObjects/s2cells.js";
 import { updateWeather } from "@/lib/mapObjects/weather.svelte";
 import type { MapObjectResponse } from "@/lib/server/queryMapObjects/MapObjectQuery";
-import { hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
+import { hasAnyFeatureAnywhere } from "@/lib/services/user/checkPerm";
 import { getUserDetails } from "@/lib/services/user/userDetails.svelte";
+import { featureFamily } from "@/lib/utils/features";
 import { getUserSettings } from "@/lib/services/userSettings.svelte.js";
 import { currentTimestamp } from "@/lib/utils/currentTimestamp";
 import { getHeaders, parseResponse } from "@/lib/utils/requests";
@@ -75,7 +76,7 @@ export async function updateMapObject(
 	signal?: AbortSignal,
 	onlyChanged: boolean = false
 ) {
-	if (!hasFeatureAnywhere(getUserDetails().permissions, type)) return;
+	if (!hasAnyFeatureAnywhere(getUserDetails().permissions, featureFamily[type])) return;
 	if (type === MapObjectType.ROUTE) return;
 
 	let filter: AnyFilter | undefined = undefined;

--- a/src/lib/server/auth/checkIfAuthed.ts
+++ b/src/lib/server/auth/checkIfAuthed.ts
@@ -1,6 +1,6 @@
 import type { User } from "@/lib/server/db/internal/schema";
 import { isAuthRequired } from "@/lib/server/auth/betterAuth";
-import { hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
+import { hasAnyFeatureAnywhere, hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
 
 import type { FeaturesKey, Perms } from "@/lib/utils/features";
 
@@ -10,4 +10,12 @@ export function checkIfAuthed(user: User | null) {
 
 export function hasFeatureAnywhereServer(perms: Perms, feature: FeaturesKey, user: User | null) {
 	return checkIfAuthed(user) && hasFeatureAnywhere(perms, feature);
+}
+
+export function hasAnyFeatureAnywhereServer(
+	perms: Perms,
+	features: FeaturesKey[],
+	user: User | null
+) {
+	return checkIfAuthed(user) && hasAnyFeatureAnywhere(perms, features);
 }

--- a/src/lib/server/queryMapObjects/MapObjectQuery.ts
+++ b/src/lib/server/queryMapObjects/MapObjectQuery.ts
@@ -2,7 +2,7 @@ import type { Bounds } from "@/lib/mapObjects/mapBounds";
 import { type MapData, MapObjectType, type MinMapObject } from "@/lib/mapObjects/mapObjectTypes";
 import { buildSpatialFilter as defaultBuildSpatialFilter } from "@/lib/server/api/spatialFilter";
 import { query as dbQuery } from "@/lib/server/db/external/internalQuery";
-import type { PermittedPolygon } from "@/lib/services/user/checkPerm";
+import type { FeaturePermissionContext, PermittedPolygon } from "@/lib/services/user/checkPerm";
 
 export type MapObjectResponse<T> = {
 	examined: number;
@@ -18,16 +18,23 @@ export abstract class MapObjectQuery<MapObject extends MapData, Filter> {
 		filter: Filter | undefined,
 		polygon: PermittedPolygon,
 		since?: number,
-		limit?: number
+		limit?: number,
+		context?: FeaturePermissionContext
 	): Promise<MapObjectResponse<MinMapObject<MapObject>>>;
 
 	abstract querySingle(id: string, thisFetch?: typeof fetch): Promise<MinMapObject<MapObject>[]>;
 
-	filter(data: MinMapObject<MapObject>, filter: Filter, polygon: PermittedPolygon): boolean {
+	filter(
+		data: MinMapObject<MapObject>,
+		filter: Filter,
+		polygon: PermittedPolygon,
+		context?: FeaturePermissionContext
+	): boolean {
 		return true;
 	}
 
-	prepare(_data: MinMapObject<MapObject>): void {}
+	// When a permission context is given, strips sub-features/data the user can't see at this location.
+	prepare(_data: MinMapObject<MapObject>, _context?: FeaturePermissionContext): void {}
 
 	makeMapObject(data: MinMapObject<MapObject>): MapObject {
 		return {
@@ -42,17 +49,18 @@ export abstract class MapObjectQuery<MapObject extends MapData, Filter> {
 		filter: Filter | undefined,
 		polygon: PermittedPolygon,
 		since?: number,
-		limit?: number
+		limit?: number,
+		context?: FeaturePermissionContext
 	): Promise<MapObjectResponse<MapObject>> {
-		const result = await this.query(bounds, filter, polygon, since, limit);
+		const result = await this.query(bounds, filter, polygon, since, limit, context);
 		for (const item of result.data) {
-			this.prepare(item);
+			this.prepare(item, context);
 		}
 
 		let examined = result.examined;
 		const data: MapObject[] = [];
 		for (const item of result.data) {
-			if (!filter || this.filter(item, filter, polygon)) {
+			if (!filter || this.filter(item, filter, polygon, context)) {
 				data.push(this.makeMapObject(item));
 			}
 		}
@@ -60,12 +68,12 @@ export abstract class MapObjectQuery<MapObject extends MapData, Filter> {
 		return { examined, data };
 	}
 
-	public async getSingle(id: string, thisFetch?: typeof fetch) {
+	public async getSingle(id: string, thisFetch?: typeof fetch, context?: FeaturePermissionContext) {
 		const mapObjects = await this.querySingle(id, thisFetch);
 		if (!mapObjects.length || !mapObjects[0]) return;
 
 		const mapObject = mapObjects[0];
-		this.prepare(mapObject);
+		this.prepare(mapObject, context);
 		return this.makeMapObject(mapObject);
 	}
 }

--- a/src/lib/server/queryMapObjects/queryGym.ts
+++ b/src/lib/server/queryMapObjects/queryGym.ts
@@ -3,8 +3,10 @@ import type { FilterGym } from "@/lib/features/filters/filters";
 import { MapObjectType, type MinMapObject } from "@/lib/mapObjects/mapObjectTypes";
 import { requestLimits } from "@/lib/server/api/rateLimit";
 import { DbMapObjectQuery } from "@/lib/server/queryMapObjects/MapObjectQuery";
-import type { PermittedPolygon } from "@/lib/services/user/checkPerm";
+import type { FeaturePermissionContext, PermittedPolygon } from "@/lib/services/user/checkPerm";
 import type { GymData, GymDefender } from "@/lib/types/mapObjectData/gym";
+import { Features } from "@/lib/utils/features";
+import { stripRaidFields } from "@/lib/utils/gymUtils";
 import { getNormalizedForm } from "@/lib/utils/pokemonUtils";
 
 export class GymQuery extends DbMapObjectQuery<GymData, FilterGym> {
@@ -53,11 +55,21 @@ export class GymQuery extends DbMapObjectQuery<GymData, FilterGym> {
 		return { sql: "", values: [] };
 	}
 
-	filter(data: MinMapObject<GymData>, filter: FilterGym, polygon: PermittedPolygon): boolean {
-		return Boolean(filter.gymPlain.enabled || shouldDisplayRaid(data, filter));
+	filter(
+		data: MinMapObject<GymData>,
+		filter: FilterGym,
+		polygon: PermittedPolygon,
+		context?: FeaturePermissionContext
+	): boolean {
+		const plainPermitted = !context || context.isAllowedAt(Features.GYM, data.lat, data.lon);
+		return Boolean((plainPermitted && filter.gymPlain.enabled) || shouldDisplayRaid(data, filter));
 	}
 
-	prepare(data: MinMapObject<GymData>): void {
+	prepare(data: MinMapObject<GymData>, context?: FeaturePermissionContext): void {
+		if (context && !context.isAllowedAt(Features.RAID, data.lat, data.lon)) {
+			stripRaidFields(data);
+		}
+
 		data.raid_pokemon_form = getNormalizedForm(data.raid_pokemon_id, data.raid_pokemon_form);
 
 		if (data.defenders_raw) {

--- a/src/lib/server/queryMapObjects/queryMapObjects.ts
+++ b/src/lib/server/queryMapObjects/queryMapObjects.ts
@@ -14,7 +14,7 @@ import { RouteQuery } from "@/lib/server/queryMapObjects/queryRoute";
 import { SpawnpointQuery } from "@/lib/server/queryMapObjects/querySpawnpoint";
 import { StationQuery } from "@/lib/server/queryMapObjects/queryStation";
 import { TappableQuery } from "@/lib/server/queryMapObjects/queryTappable";
-import type { PermittedPolygon } from "@/lib/services/user/checkPerm";
+import type { FeaturePermissionContext, PermittedPolygon } from "@/lib/services/user/checkPerm";
 import { error } from "@sveltejs/kit";
 
 const registry: Partial<Record<MapObjectType, MapObjectQuery<any, any>>> = {
@@ -40,19 +40,21 @@ export async function queryMapObjects<Data extends MapData>(
 	filter: AnyFilter | undefined,
 	polygon: PermittedPolygon = null,
 	since?: number,
-	limit?: number
+	limit?: number,
+	context?: FeaturePermissionContext
 ): Promise<MapObjectResponse<Data>> {
 	if (filter !== undefined && !filter.enabled) {
 		return { examined: 0, data: [] };
 	}
 
-	return getQuery(type).getMultiple(bounds, filter, polygon, since, limit);
+	return getQuery(type).getMultiple(bounds, filter, polygon, since, limit, context);
 }
 
 export async function querySingleMapObject(
 	type: MapObjectType,
 	id: string,
-	thisFetch: typeof fetch = fetch
+	thisFetch: typeof fetch = fetch,
+	context?: FeaturePermissionContext
 ) {
-	return getQuery(type).getSingle(id, thisFetch);
+	return getQuery(type).getSingle(id, thisFetch, context);
 }

--- a/src/lib/server/queryMapObjects/queryPokemon.ts
+++ b/src/lib/server/queryMapObjects/queryPokemon.ts
@@ -13,8 +13,9 @@ import type {
 	GolbatPokemonSpecies
 } from "@/lib/server/queryMapObjects/queries";
 import { getMasterPokemon } from "@/lib/services/masterfile";
-import type { PermittedPolygon } from "@/lib/services/user/checkPerm";
+import type { FeaturePermissionContext, PermittedPolygon } from "@/lib/services/user/checkPerm";
 import type { PokemonData, PvpStats } from "@/lib/types/mapObjectData/pokemon";
+import { Features } from "@/lib/utils/features";
 import { round } from "@/lib/utils/numberFormat";
 import { getNormalizedForm, League, showPvp } from "@/lib/utils/pokemonUtils";
 import { error } from "@sveltejs/kit";
@@ -29,9 +30,10 @@ export class PokemonQuery extends MapObjectQuery<PokemonData, FilterPokemon> {
 		filter: FilterPokemon | undefined,
 		polygon: PermittedPolygon,
 		since?: number,
-		limit?: number
+		limit?: number,
+		context?: FeaturePermissionContext
 	): Promise<MapObjectResponse<MinMapObject<PokemonData>>> {
-		const golbatQueries = this.buildGolbatQueries(filter);
+		const golbatQueries = this.buildGolbatQueries(filter, context);
 
 		const actualLimit = Math.min(limit ?? this.limit, this.limit);
 
@@ -56,7 +58,7 @@ export class PokemonQuery extends MapObjectQuery<PokemonData, FilterPokemon> {
 					examined -= 1;
 					continue;
 				}
-				const pokemon = this.makePokemon(p, filter);
+				const pokemon = this.makePokemon(p, filter, context);
 				// need to re-check pvp filters after removing mega evolutions
 				if (!shouldDisplayPokemon(pokemon, filter)) continue;
 
@@ -73,10 +75,35 @@ export class PokemonQuery extends MapObjectQuery<PokemonData, FilterPokemon> {
 		return mon ? [this.makePokemon(mon, undefined)] : [];
 	}
 
+	prepare(data: MinMapObject<PokemonData>, context?: FeaturePermissionContext): void {
+		if (!context) return;
+
+		const ivAllowed = context.isAllowedAt(Features.POKEMON_IV, data.lat, data.lon);
+		const pvpAllowed = context.isAllowedAt(Features.POKEMON_PVP, data.lat, data.lon);
+
+		if (!ivAllowed) {
+			data.iv = undefined;
+			data.atk_iv = undefined;
+			data.def_iv = undefined;
+			data.sta_iv = undefined;
+			data.size = undefined;
+		}
+		if (!pvpAllowed) data.pvp = undefined;
+		if (!ivAllowed && !pvpAllowed) {
+			data.cp = undefined;
+			data.level = undefined;
+		}
+	}
+
 	private makePokemon(
 		p: MinMapObject<PokemonData>,
-		filter: FilterPokemon | undefined
+		filter: FilterPokemon | undefined,
+		context?: FeaturePermissionContext
 	): PokemonData {
+		const ivAllowed = !context || context.isAllowedAt(Features.POKEMON_IV, p.lat, p.lon);
+		const pvpAllowed = !context || context.isAllowedAt(Features.POKEMON_PVP, p.lat, p.lon);
+		const statsAllowed = ivAllowed || pvpAllowed;
+
 		const pokemon = {
 			id: p.id,
 			lat: round(p.lat, 6),
@@ -88,13 +115,13 @@ export class PokemonQuery extends MapObjectQuery<PokemonData, FilterPokemon> {
 			alignment: p.alignment,
 			bread_mode: p.bread_mode,
 			temp_evolution_id: p.temp_evolution_id,
-			cp: p.cp,
-			level: p.level,
-			iv: p.iv || p.iv === 0 ? round(p.iv, 2) : undefined,
-			atk_iv: p.atk_iv,
-			def_iv: p.def_iv,
-			sta_iv: p.sta_iv,
-			size: p.size,
+			cp: statsAllowed ? p.cp : undefined,
+			level: statsAllowed ? p.level : undefined,
+			iv: ivAllowed && (p.iv || p.iv === 0) ? round(p.iv, 2) : undefined,
+			atk_iv: ivAllowed ? p.atk_iv : undefined,
+			def_iv: ivAllowed ? p.def_iv : undefined,
+			sta_iv: ivAllowed ? p.sta_iv : undefined,
+			size: ivAllowed ? p.size : undefined,
 			weather: p.weather,
 			strong: p.strong,
 			move_1: p.move_1,
@@ -109,27 +136,29 @@ export class PokemonQuery extends MapObjectQuery<PokemonData, FilterPokemon> {
 			seen_type: p.seen_type
 		} as PokemonData;
 
-		const littleRankings: PvpStats[] = [];
-		const greatRankings: PvpStats[] = [];
-		const ultraRankings: PvpStats[] = [];
+		if (pvpAllowed) {
+			const littleRankings: PvpStats[] = [];
+			const greatRankings: PvpStats[] = [];
+			const ultraRankings: PvpStats[] = [];
 
-		for (const rankings of p.pvp?.[League.LITTLE] ?? []) {
-			if (showPvp(rankings.rank, "pvpRankLittle", false, filter ?? null))
-				this.makePvpStats(littleRankings, rankings);
-		}
-		for (const rankings of p.pvp?.[League.GREAT] ?? []) {
-			if (showPvp(rankings.rank, "pvpRankGreat", false, filter ?? null))
-				this.makePvpStats(greatRankings, rankings);
-		}
-		for (const rankings of p.pvp?.[League.ULTRA] ?? []) {
-			if (showPvp(rankings.rank, "pvpRankUltra", false, filter ?? null))
-				this.makePvpStats(ultraRankings, rankings);
-		}
-		if (littleRankings.length || greatRankings.length || ultraRankings.length) {
-			pokemon.pvp = {};
-			if (littleRankings.length) pokemon.pvp[League.LITTLE] = littleRankings;
-			if (greatRankings.length) pokemon.pvp[League.GREAT] = greatRankings;
-			if (ultraRankings.length) pokemon.pvp[League.ULTRA] = ultraRankings;
+			for (const rankings of p.pvp?.[League.LITTLE] ?? []) {
+				if (showPvp(rankings.rank, "pvpRankLittle", false, filter ?? null))
+					this.makePvpStats(littleRankings, rankings);
+			}
+			for (const rankings of p.pvp?.[League.GREAT] ?? []) {
+				if (showPvp(rankings.rank, "pvpRankGreat", false, filter ?? null))
+					this.makePvpStats(greatRankings, rankings);
+			}
+			for (const rankings of p.pvp?.[League.ULTRA] ?? []) {
+				if (showPvp(rankings.rank, "pvpRankUltra", false, filter ?? null))
+					this.makePvpStats(ultraRankings, rankings);
+			}
+			if (littleRankings.length || greatRankings.length || ultraRankings.length) {
+				pokemon.pvp = {};
+				if (littleRankings.length) pokemon.pvp[League.LITTLE] = littleRankings;
+				if (greatRankings.length) pokemon.pvp[League.GREAT] = greatRankings;
+				if (ultraRankings.length) pokemon.pvp[League.ULTRA] = ultraRankings;
+			}
 		}
 		return pokemon;
 	}
@@ -148,7 +177,15 @@ export class PokemonQuery extends MapObjectQuery<PokemonData, FilterPokemon> {
 		});
 	}
 
-	private buildGolbatQueries(filter: FilterPokemon | undefined): GolbatPokemonQuery[] {
+	private buildGolbatQueries(
+		filter: FilterPokemon | undefined,
+		context?: FeaturePermissionContext
+	): GolbatPokemonQuery[] {
+		// Numeric iv/pvp constraints would leak whether unseen mons match. Only push them to
+		// Golbat when the tier is granted globally; otherwise drop them and strip per-object.
+		const ivConstraintsAllowed = !context || context.allowedEverywhere(Features.POKEMON_IV);
+		const pvpConstraintsAllowed = !context || context.allowedEverywhere(Features.POKEMON_PVP);
+
 		const enabledFilters = filter?.filters?.filter((f) => f.enabled) ?? [];
 		if (enabledFilters.length === 0) {
 			return [{ pokemon: [] }];
@@ -188,17 +225,23 @@ export class PokemonQuery extends MapObjectQuery<PokemonData, FilterPokemon> {
 				}
 			}
 
-			if (filter.iv) query.iv = filter.iv;
-			if (filter.ivAtk) query.atk_iv = filter.ivAtk;
-			if (filter.ivDef) query.def_iv = filter.ivDef;
-			if (filter.ivSta) query.sta_iv = filter.ivSta;
-			if (filter.level) query.level = filter.level;
-			if (filter.cp) query.cp = filter.cp;
+			if (ivConstraintsAllowed) {
+				if (filter.iv) query.iv = filter.iv;
+				if (filter.ivAtk) query.atk_iv = filter.ivAtk;
+				if (filter.ivDef) query.def_iv = filter.ivDef;
+				if (filter.ivSta) query.sta_iv = filter.ivSta;
+				if (filter.size) query.size = filter.size;
+			}
+			if (ivConstraintsAllowed || pvpConstraintsAllowed) {
+				if (filter.level) query.level = filter.level;
+				if (filter.cp) query.cp = filter.cp;
+			}
 			if (filter.gender) query.gender = filter.gender;
-			if (filter.size) query.size = filter.size;
-			if (filter.pvpRankLittle) query.pvp_little = filter.pvpRankLittle;
-			if (filter.pvpRankGreat) query.pvp_great = filter.pvpRankGreat;
-			if (filter.pvpRankUltra) query.pvp_ultra = filter.pvpRankUltra;
+			if (pvpConstraintsAllowed) {
+				if (filter.pvpRankLittle) query.pvp_little = filter.pvpRankLittle;
+				if (filter.pvpRankGreat) query.pvp_great = filter.pvpRankGreat;
+				if (filter.pvpRankUltra) query.pvp_ultra = filter.pvpRankUltra;
+			}
 
 			return query;
 		});

--- a/src/lib/server/queryMapObjects/queryPokestop.ts
+++ b/src/lib/server/queryMapObjects/queryPokestop.ts
@@ -8,11 +8,21 @@ import { MapObjectType, type MinMapObject } from "@/lib/mapObjects/mapObjectType
 import { requestLimits } from "@/lib/server/api/rateLimit";
 import { queryJoined } from "@/lib/server/db/external/internalQuery";
 import { DbMapObjectQuery } from "@/lib/server/queryMapObjects/MapObjectQuery";
-import type { PermittedPolygon } from "@/lib/services/user/checkPerm";
-import type { PokestopData } from "@/lib/types/mapObjectData/pokestop";
+import type { FeaturePermissionContext, PermittedPolygon } from "@/lib/services/user/checkPerm";
+import type { Incident, PokestopData } from "@/lib/types/mapObjectData/pokestop";
 import { currentTimestamp } from "@/lib/utils/currentTimestamp";
+import { Features } from "@/lib/utils/features";
 import { getNormalizedForm } from "@/lib/utils/pokemonUtils";
-import { parseQuestReward } from "@/lib/utils/pokestopUtils";
+import {
+	isIncidentContest,
+	isIncidentGold,
+	isIncidentInvasion,
+	isIncidentKecleon,
+	parseQuestReward,
+	stripContestFields,
+	stripLureFields,
+	stripQuestFields
+} from "@/lib/utils/pokestopUtils";
 
 const FIELDS_POKESTOP = [
 	"pokestop.id",
@@ -76,9 +86,14 @@ export class PokestopQuery extends DbMapObjectQuery<PokestopData, FilterPokestop
 	filter(
 		data: MinMapObject<PokestopData>,
 		filter: FilterPokestop,
-		polygon: PermittedPolygon
+		polygon: PermittedPolygon,
+		context?: FeaturePermissionContext
 	): boolean {
-		let showThis = Boolean(filter.pokestopPlain.enabled || shouldDisplayLure(data, filter));
+		const plainPermitted = !context || context.isAllowedAt(Features.POKESTOP, data.lat, data.lon);
+
+		let showThis = Boolean(
+			(plainPermitted && filter.pokestopPlain.enabled) || shouldDisplayLure(data, filter)
+		);
 
 		if (!showThis && filter.quest.enabled) {
 			const quest = data.quests[0];
@@ -99,7 +114,27 @@ export class PokestopQuery extends DbMapObjectQuery<PokestopData, FilterPokestop
 		return showThis;
 	}
 
-	prepare(data: MinMapObject<PokestopData>): void {
+	private stripUnpermitted(
+		data: MinMapObject<PokestopData>,
+		context: FeaturePermissionContext
+	): void {
+		const at = (feature: Parameters<FeaturePermissionContext["isAllowedAt"]>[0]) =>
+			context.isAllowedAt(feature, data.lat, data.lon);
+
+		if (!at(Features.QUEST)) stripQuestFields(data);
+		if (!at(Features.LURE)) stripLureFields(data);
+		if (!at(Features.CONTEST)) stripContestFields(data);
+
+		data.incident = (data.incident ?? []).filter((incident: Incident) => {
+			if (isIncidentInvasion(incident)) return at(Features.INVASION);
+			if (isIncidentKecleon(incident)) return at(Features.KECLEON);
+			if (isIncidentGold(incident)) return at(Features.GOLDEN_POKESTOP);
+			if (isIncidentContest(incident)) return at(Features.CONTEST);
+			return false;
+		});
+	}
+
+	prepare(data: MinMapObject<PokestopData>, context?: FeaturePermissionContext): void {
 		data.quests = [];
 		if (data.alternative_quest_target && data.alternative_quest_rewards) {
 			const reward = parseQuestReward(data.alternative_quest_rewards);
@@ -146,5 +181,7 @@ export class PokestopQuery extends DbMapObjectQuery<PokestopData, FilterPokestop
 			incident.slot_2_form = getNormalizedForm(incident.slot_2_pokemon_id, incident.slot_2_form);
 			incident.slot_3_form = getNormalizedForm(incident.slot_3_pokemon_id, incident.slot_3_form);
 		}
+
+		if (context) this.stripUnpermitted(data, context);
 	}
 }

--- a/src/lib/server/queryMapObjects/queryStation.ts
+++ b/src/lib/server/queryMapObjects/queryStation.ts
@@ -3,8 +3,9 @@ import type { FilterStation } from "@/lib/features/filters/filters";
 import { MapObjectType, type MinMapObject } from "@/lib/mapObjects/mapObjectTypes";
 import { requestLimits } from "@/lib/server/api/rateLimit";
 import { DbMapObjectQuery } from "@/lib/server/queryMapObjects/MapObjectQuery";
-import type { PermittedPolygon } from "@/lib/services/user/checkPerm";
+import type { FeaturePermissionContext, PermittedPolygon } from "@/lib/services/user/checkPerm";
 import type { StationData } from "@/lib/types/mapObjectData/station";
+import { Features } from "@/lib/utils/features";
 import { getNormalizedForm } from "@/lib/utils/pokemonUtils";
 import { isMaxBattleActive, stripMaxBattleFields } from "@/lib/utils/stationUtils";
 
@@ -49,15 +50,36 @@ export class StationQuery extends DbMapObjectQuery<StationData, FilterStation> {
 	filter(
 		data: MinMapObject<StationData>,
 		filter: FilterStation,
-		polygon: PermittedPolygon
+		polygon: PermittedPolygon,
+		context?: FeaturePermissionContext
 	): boolean {
-		if (!shouldDisplayStation(data, filter)) return false;
-		if (!filter.maxBattle.enabled) stripMaxBattleFields(data);
+		const plainPermitted = !context || context.isAllowedAt(Features.STATION, data.lat, data.lon);
+		const maxBattlePermitted =
+			!context || context.isAllowedAt(Features.MAX_BATTLE, data.lat, data.lon);
+
+		const effectiveFilter: FilterStation =
+			plainPermitted && maxBattlePermitted
+				? filter
+				: {
+						...filter,
+						stationPlain: plainPermitted
+							? filter.stationPlain
+							: { ...filter.stationPlain, enabled: false },
+						maxBattle: maxBattlePermitted
+							? filter.maxBattle
+							: { ...filter.maxBattle, enabled: false }
+					};
+
+		if (!shouldDisplayStation(data, effectiveFilter)) return false;
+		if (!filter.maxBattle.enabled || !maxBattlePermitted) stripMaxBattleFields(data);
 		return true;
 	}
 
-	prepare(data: MinMapObject<StationData>): void {
+	prepare(data: MinMapObject<StationData>, context?: FeaturePermissionContext): void {
 		data.battle_pokemon_form = getNormalizedForm(data.battle_pokemon_id, data.battle_pokemon_form);
 		if (!isMaxBattleActive(data)) stripMaxBattleFields(data);
+		if (context && !context.isAllowedAt(Features.MAX_BATTLE, data.lat, data.lon)) {
+			stripMaxBattleFields(data);
+		}
 	}
 }

--- a/src/lib/services/search.svelte.ts
+++ b/src/lib/services/search.svelte.ts
@@ -17,7 +17,8 @@ import { m } from "@/lib/paraglide/messages";
 import { mCharacter, mItem, mPokemon, mRaid } from "@/lib/services/ingameLocale";
 import { getAllLureModuleIds } from "@/lib/services/masterfile";
 import { isSupportedFeature } from "@/lib/services/supportedFeatures";
-import { hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
+import { hasAnyFeatureAnywhere, hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
+import { featureFamily, Features } from "@/lib/utils/features";
 import { getUserDetails } from "@/lib/services/user/userDetails.svelte";
 import type { ContestFocus, QuestReward } from "@/lib/types/mapObjectData/pokestop";
 import { openModal } from "@/lib/ui/modal.svelte";
@@ -297,7 +298,7 @@ export function initSearch(searchOptions: SearchOptions) {
 	let pokemonEntries: PokemonSearchEntry[] = [];
 	if (
 		shouldSearchType(SearchableType.POKEMON, searchOptions) &&
-		hasFeatureAnywhere(permissions, MapObjectType.POKEMON)
+		hasAnyFeatureAnywhere(permissions, featureFamily[MapObjectType.POKEMON])
 	) {
 		pokemonEntries = getSpawnablePokemon().map((p) => {
 			return {
@@ -318,7 +319,7 @@ export function initSearch(searchOptions: SearchOptions) {
 	let questEntries: QuestSearchEntry[] = [];
 	if (
 		shouldSearchType(SearchableType.QUEST, searchOptions) &&
-		hasFeatureAnywhere(permissions, MapObjectType.POKESTOP)
+		hasFeatureAnywhere(permissions, Features.QUEST)
 	) {
 		questEntries =
 			getActiveQuestRewards()?.map((r) => {
@@ -341,7 +342,7 @@ export function initSearch(searchOptions: SearchOptions) {
 	let kecleonEntries: KecleonSearchEntry[] = [];
 	if (
 		shouldSearchType(SearchableType.KECLEON, searchOptions) &&
-		hasFeatureAnywhere(permissions, MapObjectType.POKESTOP)
+		hasFeatureAnywhere(permissions, Features.KECLEON)
 	) {
 		kecleonEntries = [
 			{
@@ -356,7 +357,7 @@ export function initSearch(searchOptions: SearchOptions) {
 	let contestEntries: ContestSearchEntry[] = [];
 	if (
 		shouldSearchType(SearchableType.CONTEST, searchOptions) &&
-		hasFeatureAnywhere(permissions, MapObjectType.POKESTOP)
+		hasFeatureAnywhere(permissions, Features.CONTEST)
 	) {
 		contestEntries = getActiveContests().map((contest) => {
 			return {
@@ -373,7 +374,7 @@ export function initSearch(searchOptions: SearchOptions) {
 	let lureEntries: LureSearchEntry[] = [];
 	if (
 		shouldSearchType(SearchableType.LURE, searchOptions) &&
-		hasFeatureAnywhere(permissions, MapObjectType.POKESTOP)
+		hasFeatureAnywhere(permissions, Features.LURE)
 	) {
 		lureEntries = getAllLureModuleIds().map((lure) => {
 			return {
@@ -389,7 +390,7 @@ export function initSearch(searchOptions: SearchOptions) {
 	let invasionEntries: InvasionSearchEntry[] = [];
 	if (
 		shouldSearchType(SearchableType.INVASION, searchOptions) &&
-		hasFeatureAnywhere(permissions, MapObjectType.POKESTOP)
+		hasFeatureAnywhere(permissions, Features.INVASION)
 	) {
 		invasionEntries = getActiveCharacters().map((character) => {
 			return {
@@ -408,7 +409,7 @@ export function initSearch(searchOptions: SearchOptions) {
 	if (
 		(shouldSearchType(SearchableType.RAID_LEVEL, searchOptions) ||
 			shouldSearchType(SearchableType.RAID_BOSS, searchOptions)) &&
-		hasFeatureAnywhere(permissions, MapObjectType.GYM)
+		hasFeatureAnywhere(permissions, Features.RAID)
 	) {
 		raidBossEntries = getActiveRaids()
 			.map((raidBoss) => {
@@ -443,7 +444,7 @@ export function initSearch(searchOptions: SearchOptions) {
 	let maxBattleBossEntries: MaxBattleBossSearchEntry[] = [];
 	if (
 		shouldSearchType(SearchableType.MAX_BATTLE_BOSS, searchOptions) &&
-		hasFeatureAnywhere(permissions, MapObjectType.STATION)
+		hasFeatureAnywhere(permissions, Features.MAX_BATTLE)
 	) {
 		maxBattleBossEntries = getActiveMaxBattles().map((maxBattle) => {
 			return {
@@ -595,8 +596,14 @@ export function addAddressSearchResults(data: AddressData[], query: string) {
 }
 
 async function getFortSearchEntries(searchOptions: SearchOptions, map?: maplibre.Map) {
-	const hasPokestops = hasFeatureAnywhere(getUserDetails().permissions, MapObjectType.POKESTOP);
-	const hasGyms = hasFeatureAnywhere(getUserDetails().permissions, MapObjectType.GYM);
+	const hasPokestops = hasAnyFeatureAnywhere(
+		getUserDetails().permissions,
+		[Features.POKESTOP]
+	);
+	const hasGyms = hasAnyFeatureAnywhere(
+		getUserDetails().permissions,
+		[Features.GYM]
+	);
 	if (!hasGyms && !hasPokestops) return;
 
 	const usedMap = map ?? getMap();

--- a/src/lib/services/user/checkPerm.ts
+++ b/src/lib/services/user/checkPerm.ts
@@ -1,5 +1,11 @@
 import type { Bounds } from "@/lib/mapObjects/mapBounds";
-import { Features, type FeaturesKey, type Perms } from "@/lib/utils/features";
+import {
+	Features,
+	featureImplies,
+	featureWildcardAncestors,
+	type FeaturesKey,
+	type Perms
+} from "@/lib/utils/features";
 import { getLogger } from "@/lib/utils/logger";
 import {
 	bbox,
@@ -18,7 +24,13 @@ const log = getLogger("permissions");
 function isFeatureInFeatureList(featureList: FeaturesKey[] | undefined, feature: FeaturesKey) {
 	if (featureList === undefined) return false;
 
-	return featureList.includes(Features.ALL) || featureList.includes(feature);
+	if (featureList.includes(Features.ALL) || featureList.includes(feature)) return true;
+
+	const wildcards = featureWildcardAncestors[feature];
+	if (wildcards !== undefined && wildcards.some((wildcard) => featureList.includes(wildcard)))
+		return true;
+
+	return featureList.some((held) => featureImplies[held]?.includes(feature));
 }
 
 export function hasFeatureAnywhere(perms: Perms, feature: FeaturesKey) {
@@ -30,6 +42,10 @@ export function hasFeatureAnywhere(perms: Perms, feature: FeaturesKey) {
 		}
 	}
 	return false;
+}
+
+export function hasAnyFeatureAnywhere(perms: Perms, features: FeaturesKey[]) {
+	return features.some((feature) => hasFeatureAnywhere(perms, feature));
 }
 
 export type PermittedPolygon = Feature<Polygon | MultiPolygon> | null;
@@ -44,7 +60,19 @@ export function checkFeatureInBounds(
 	feature: FeaturesKey,
 	bounds: Bounds
 ): PermittedBounds | null {
-	if (isFeatureInFeatureList(perms.everywhere, feature)) return { bounds, polygon: null };
+	return checkFeaturesInBounds(perms, [feature], bounds);
+}
+
+// Union of the permitted areas across a set of features (e.g. a whole object family), so an
+// object is returned when any of them is permitted there. Per-feature stripping happens later.
+export function checkFeaturesInBounds(
+	perms: Perms,
+	features: FeaturesKey[],
+	bounds: Bounds
+): PermittedBounds | null {
+	if (features.some((feature) => isFeatureInFeatureList(perms.everywhere, feature))) {
+		return { bounds, polygon: null };
+	}
 
 	const start = performance.now();
 
@@ -60,19 +88,17 @@ export function checkFeatureInBounds(
 
 	const permittedPolygons: Feature<Polygon>[] = [];
 	for (const area of perms.areas) {
-		if (isFeatureInFeatureList(area.features, feature)) {
+		if (features.some((feature) => isFeatureInFeatureList(area.features, feature))) {
 			if (area.polygon) {
 				permittedPolygons.push(makeFeature(area.polygon));
 			}
 		}
 	}
 
-	// If no permitted areas have this feature (or none have polygons), deny access
 	if (permittedPolygons.length === 0) {
 		return null;
 	}
 
-	// Find intersection of viewport with each permitted area and collect results
 	let combinedIntersection: PermittedPolygon = null;
 	for (const permittedPolygon of permittedPolygons) {
 		const areaIntersection = intersect(featureCollection([viewportPolygon, permittedPolygon]));
@@ -91,14 +117,13 @@ export function checkFeatureInBounds(
 	}
 
 	log.debug(
-		"calculated area intersections | areas: %d | feature: %s | any match permissions: %s | took: %fms",
+		"calculated area intersections | areas: %d | features: %s | any match permissions: %s | took: %fms",
 		permittedPolygons.length,
-		feature,
+		features.join(","),
 		Boolean(combinedIntersection),
 		(performance.now() - start).toFixed(1)
 	);
 
-	// If no intersection with any permitted area, deny access
 	if (!combinedIntersection) {
 		return null;
 	}
@@ -147,4 +172,45 @@ export function isPointInAllowedArea(
 	);
 
 	return isAllowed;
+}
+
+// Precomputes, for a fixed set of features, whether each is granted everywhere and the polygons
+// granting it, so the query layer can strip per object: "everywhere" needs no geometry, otherwise
+// a point-in-polygon test.
+export class FeaturePermissionContext {
+	private readonly everywhere = new Set<FeaturesKey>();
+	private readonly areaPolygons = new Map<FeaturesKey, Feature<Polygon>[]>();
+
+	constructor(perms: Perms, features: FeaturesKey[]) {
+		for (const feature of features) {
+			if (isFeatureInFeatureList(perms.everywhere, feature)) {
+				this.everywhere.add(feature);
+				continue;
+			}
+
+			const polygons: Feature<Polygon>[] = [];
+			for (const area of perms.areas ?? []) {
+				if (isFeatureInFeatureList(area.features, feature) && area.polygon) {
+					polygons.push(makeFeature(area.polygon));
+				}
+			}
+			if (polygons.length > 0) {
+				this.areaPolygons.set(feature, polygons);
+			}
+		}
+	}
+
+	allowedEverywhere(feature: FeaturesKey): boolean {
+		return this.everywhere.has(feature);
+	}
+
+	isAllowedAt(feature: FeaturesKey, lat: number, lon: number): boolean {
+		if (this.everywhere.has(feature)) return true;
+
+		const polygons = this.areaPolygons.get(feature);
+		if (!polygons) return false;
+
+		const turfPoint = point([lon, lat]);
+		return polygons.some((poly) => booleanPointInPolygon(turfPoint, poly));
+	}
 }

--- a/src/lib/utils/features.ts
+++ b/src/lib/utils/features.ts
@@ -1,14 +1,117 @@
 import { MapObjectType } from "@/lib/mapObjects/mapObjectTypes";
 import type { Polygon } from "geojson";
 
-enum NonMapObjectFeature {
+enum ExtraFeature {
 	ALL = "*",
+
+	POKEMON_IV = "pokemon_iv",
+	POKEMON_PVP = "pokemon_pvp",
+	POKEMON_ALL = "pokemon*",
+
+	QUEST = "quest",
+	INVASION = "invasion",
+	LURE = "lure",
+	CONTEST = "contest",
+	KECLEON = "kecleon",
+	GOLDEN_POKESTOP = "golden_pokestop",
+	POKESTOP_ALL = "pokestop*",
+
+	RAID = "raid",
+	GYM_ALL = "gym*",
+
+	MAX_BATTLE = "max_battle",
+	STATION_ALL = "station*",
+
 	SCOUT = "scout",
-	WEATHER = "weather"
+	WEATHER = "weather",
+	COVERAGE_MAP = "coverage_map",
+	WAYFARER_MAP = "wayfarer_map",
+	SEARCH = "search",
+
+	MAP_OBJECT_ALL = "map_object*",
+	MINOR_MAP_OBJECT_ALL = "minor_map_object*",
+	TOOL_ALL = "tool*",
+	UI_ALL = "ui*"
 }
 
-export const Features = { ...MapObjectType, ...NonMapObjectFeature };
-export type FeaturesKey = MapObjectType | NonMapObjectFeature;
+export const Features = { ...MapObjectType, ...ExtraFeature };
+export type FeaturesKey = MapObjectType | ExtraFeature;
+
+export const featureFamily: Record<MapObjectType, FeaturesKey[]> = {
+	[MapObjectType.POKEMON]: [
+		Features.POKEMON,
+		Features.POKEMON_IV,
+		Features.POKEMON_PVP,
+		Features.POKEMON_ALL
+	],
+	[MapObjectType.POKESTOP]: [
+		Features.POKESTOP,
+		Features.QUEST,
+		Features.INVASION,
+		Features.LURE,
+		Features.CONTEST,
+		Features.KECLEON,
+		Features.GOLDEN_POKESTOP,
+		Features.POKESTOP_ALL
+	],
+	[MapObjectType.GYM]: [Features.GYM, Features.RAID, Features.GYM_ALL],
+	[MapObjectType.STATION]: [Features.STATION, Features.MAX_BATTLE, Features.STATION_ALL],
+	[MapObjectType.NEST]: [Features.NEST],
+	[MapObjectType.TAPPABLE]: [Features.TAPPABLE],
+	[MapObjectType.S2_CELL]: [Features.S2_CELL],
+	[MapObjectType.SPAWNPOINT]: [Features.SPAWNPOINT],
+	[MapObjectType.ROUTE]: [Features.ROUTE]
+};
+
+export const featureWildcardChildren: Partial<Record<FeaturesKey, FeaturesKey[]>> = {
+	[Features.POKEMON_ALL]: [Features.POKEMON, Features.POKEMON_IV, Features.POKEMON_PVP],
+	[Features.POKESTOP_ALL]: [
+		Features.POKESTOP,
+		Features.QUEST,
+		Features.INVASION,
+		Features.LURE,
+		Features.CONTEST,
+		Features.KECLEON,
+		Features.GOLDEN_POKESTOP
+	],
+	[Features.GYM_ALL]: [Features.GYM, Features.RAID],
+	[Features.STATION_ALL]: [Features.STATION, Features.MAX_BATTLE],
+	[Features.MINOR_MAP_OBJECT_ALL]: [
+		Features.NEST,
+		Features.TAPPABLE,
+		Features.S2_CELL,
+		Features.SPAWNPOINT,
+		Features.ROUTE
+	],
+	[Features.MAP_OBJECT_ALL]: [
+		Features.POKEMON_ALL,
+		Features.POKESTOP_ALL,
+		Features.GYM_ALL,
+		Features.STATION_ALL,
+		Features.MINOR_MAP_OBJECT_ALL
+	],
+	[Features.TOOL_ALL]: [Features.SCOUT, Features.WAYFARER_MAP, Features.COVERAGE_MAP],
+	[Features.UI_ALL]: [Features.SEARCH, Features.WEATHER]
+};
+
+function expandWildcard(wildcard: FeaturesKey, acc = new Set<FeaturesKey>()): Set<FeaturesKey> {
+	for (const child of featureWildcardChildren[wildcard] ?? []) {
+		acc.add(child);
+		if (featureWildcardChildren[child]) expandWildcard(child, acc);
+	}
+	return acc;
+}
+
+export const featureWildcardAncestors: Partial<Record<FeaturesKey, FeaturesKey[]>> = {};
+for (const wildcard of Object.keys(featureWildcardChildren) as FeaturesKey[]) {
+	for (const descendant of expandWildcard(wildcard)) {
+		(featureWildcardAncestors[descendant] ??= []).push(wildcard);
+	}
+}
+
+export const featureImplies: Partial<Record<FeaturesKey, FeaturesKey[]>> = {
+	[Features.POKEMON_PVP]: [Features.POKEMON_IV]
+};
 
 export type PermArea = {
 	name: string;

--- a/src/lib/utils/gymUtils.ts
+++ b/src/lib/utils/gymUtils.ts
@@ -10,6 +10,27 @@ import { currentTimestamp } from "@/lib/utils/currentTimestamp";
 export type RaidFilterType = "level" | "boss";
 export const GYM_SLOTS = 6;
 
+const RAID_FIELDS = [
+	"raid_end_timestamp",
+	"raid_spawn_timestamp",
+	"raid_battle_timestamp",
+	"raid_pokemon_id",
+	"raid_level",
+	"raid_pokemon_move_1",
+	"raid_pokemon_move_2",
+	"raid_pokemon_form",
+	"raid_pokemon_cp",
+	"raid_is_exclusive",
+	"raid_pokemon_gender",
+	"raid_pokemon_costume",
+	"raid_pokemon_evolution",
+	"raid_pokemon_alignment"
+] as const satisfies readonly (keyof GymData)[];
+
+export function stripRaidFields(data: Partial<GymData>) {
+	for (const field of RAID_FIELDS) delete data[field];
+}
+
 export enum RaidLevel {
 	STAR_1 = 1,
 	SHADOW_STAR_1 = 11,

--- a/src/lib/utils/pokestopUtils.ts
+++ b/src/lib/utils/pokestopUtils.ts
@@ -75,6 +75,62 @@ export function isIncidentContest(incident: Incident) {
 	return incident.display_type === INCIDENT_DISPLAY_CONTEST;
 }
 
+const QUEST_FIELDS = [
+	"quest_type",
+	"quest_timestamp",
+	"quest_target",
+	"quest_conditions",
+	"quest_rewards",
+	"quest_template",
+	"quest_title",
+	"quest_expiry",
+	"quest_reward_type",
+	"quest_item_id",
+	"quest_reward_amount",
+	"quest_pokemon_id",
+	"alternative_quest_type",
+	"alternative_quest_timestamp",
+	"alternative_quest_target",
+	"alternative_quest_conditions",
+	"alternative_quest_rewards",
+	"alternative_quest_template",
+	"alternative_quest_title",
+	"alternative_quest_expiry",
+	"alternative_quest_pokemon_id",
+	"alternative_quest_reward_type",
+	"alternative_quest_item_id",
+	"alternative_quest_reward_amount"
+] as const satisfies readonly (keyof PokestopData)[];
+
+const LURE_FIELDS = [
+	"lure_id",
+	"lure_expire_timestamp"
+] as const satisfies readonly (keyof PokestopData)[];
+
+const CONTEST_FIELDS = [
+	"showcase_pokemon_id",
+	"showcase_pokemon_form_id",
+	"showcase_focus",
+	"contest_focus",
+	"showcase_pokemon_type_id",
+	"showcase_ranking_standard",
+	"showcase_expiry",
+	"showcase_rankings"
+] as const satisfies readonly (keyof PokestopData)[];
+
+export function stripQuestFields(data: Partial<PokestopData>) {
+	data.quests = [];
+	for (const field of QUEST_FIELDS) delete data[field];
+}
+
+export function stripLureFields(data: Partial<PokestopData>) {
+	for (const field of LURE_FIELDS) delete data[field];
+}
+
+export function stripContestFields(data: Partial<PokestopData>) {
+	for (const field of CONTEST_FIELDS) delete data[field];
+}
+
 export function getRewardText(reward: QuestReward) {
 	switch (reward.type) {
 		case RewardType.XP:

--- a/src/routes/api/[queryMapObject=mapObject]/+server.ts
+++ b/src/routes/api/[queryMapObject=mapObject]/+server.ts
@@ -8,9 +8,10 @@ import {
 	requestLimits
 } from "@/lib/server/api/rateLimit";
 import { respond } from "@/lib/server/api/respond";
-import { hasFeatureAnywhereServer } from "@/lib/server/auth/checkIfAuthed";
+import { hasAnyFeatureAnywhereServer } from "@/lib/server/auth/checkIfAuthed";
 import { queryMapObjects } from "@/lib/server/queryMapObjects/queryMapObjects";
-import { checkFeatureInBounds } from "@/lib/services/user/checkPerm";
+import { checkFeaturesInBounds, FeaturePermissionContext } from "@/lib/services/user/checkPerm";
+import { featureFamily } from "@/lib/utils/features";
 import { getLogger } from "@/lib/utils/logger";
 import { error } from "@sveltejs/kit";
 import { constants } from "http2";
@@ -21,17 +22,20 @@ const log = getLogger("mapobjects");
 export const POST: RequestHandler = async ({ request, locals, params, getClientAddress }) => {
 	const rateLimitKey = locals.user?.id ?? getClientAddress();
 	const type = params.queryMapObject as MapObjectType;
+	const family = featureFamily[type];
 
 	const start = performance.now();
-	if (!hasFeatureAnywhereServer(locals.perms, params.queryMapObject, locals.user)) error(401);
+	if (!hasAnyFeatureAnywhereServer(locals.perms, family, locals.user)) error(401);
 	const permCheckTime = performance.now();
 
 	const data: MapObjectRequestData = await request.json();
-	const permitted = checkFeatureInBounds(locals.perms, params.queryMapObject, data);
+	const permitted = checkFeaturesInBounds(locals.perms, family, data);
 
 	if (!permitted) {
 		return respond(request, { data: [] }, { status: constants.HTTP_STATUS_UNAUTHORIZED });
 	}
+
+	const permissionContext = new FeaturePermissionContext(locals.perms, family);
 
 	const requestLimit = requestLimits[type];
 	const [allowed, _, totalLimit, headers] = await rateLimitConsume(
@@ -60,7 +64,8 @@ export const POST: RequestHandler = async ({ request, locals, params, getClientA
 		data.filter,
 		permitted.polygon,
 		data.since,
-		requestLimit
+		requestLimit,
+		permissionContext
 	).catch(async (e) => {
 		await rateLimitReward(rateLimitKey, requestLimit, type);
 		throw e;

--- a/src/routes/api/[queryMapObject=mapObject]/[id]/+server.ts
+++ b/src/routes/api/[queryMapObject=mapObject]/[id]/+server.ts
@@ -1,9 +1,10 @@
 import type { MapObjectType } from "@/lib/mapObjects/mapObjectTypes";
 import { rateLimitConsume } from "@/lib/server/api/rateLimit";
 import { respond } from "@/lib/server/api/respond";
-import { hasFeatureAnywhereServer } from "@/lib/server/auth/checkIfAuthed";
+import { hasAnyFeatureAnywhereServer } from "@/lib/server/auth/checkIfAuthed";
 import { querySingleMapObject } from "@/lib/server/queryMapObjects/queryMapObjects";
-import { isPointInAllowedArea } from "@/lib/services/user/checkPerm";
+import { FeaturePermissionContext } from "@/lib/services/user/checkPerm";
+import { featureFamily } from "@/lib/utils/features";
 import { getLogger } from "@/lib/utils/logger";
 import { error, json } from "@sveltejs/kit";
 import { constants } from "http2";
@@ -14,10 +15,13 @@ const log = getLogger("mapobject id");
 export const GET: RequestHandler = async ({ params, locals, fetch, getClientAddress, request }) => {
 	const rateLimitKey = locals.user?.id ?? getClientAddress();
 	const type = params.queryMapObject as MapObjectType;
+	const family = featureFamily[type];
 
 	const start = performance.now();
-	if (!hasFeatureAnywhereServer(locals.perms, params.queryMapObject, locals.user))
+	if (!hasAnyFeatureAnywhereServer(locals.perms, family, locals.user))
 		error(constants.HTTP_STATUS_UNAUTHORIZED);
+
+	const permissionContext = new FeaturePermissionContext(locals.perms, family);
 
 	const [allowed, _remaining, totalLimit, headers] = await rateLimitConsume(rateLimitKey, 2, type);
 	if (!allowed) {
@@ -34,11 +38,16 @@ export const GET: RequestHandler = async ({ params, locals, fetch, getClientAddr
 		);
 	}
 
-	const data = await querySingleMapObject(params.queryMapObject, params.id, fetch);
+	const data = await querySingleMapObject(
+		params.queryMapObject,
+		params.id,
+		fetch,
+		permissionContext
+	);
 
 	if (!data) error(constants.HTTP_STATUS_NOT_FOUND);
 
-	if (!isPointInAllowedArea(locals.perms, params.queryMapObject, data.lat, data.lon))
+	if (!family.some((feature) => permissionContext.isAllowedAt(feature, data.lat, data.lon)))
 		error(constants.HTTP_STATUS_UNAUTHORIZED);
 
 	log.info(

--- a/src/routes/api/search/forts/+server.ts
+++ b/src/routes/api/search/forts/+server.ts
@@ -1,24 +1,24 @@
 import type { Bounds } from "@/lib/mapObjects/mapBounds";
-import { MapObjectType } from "@/lib/mapObjects/mapObjectTypes";
 import { buildSpatialFilter } from "@/lib/server/api/spatialFilter";
-import { hasFeatureAnywhereServer } from "@/lib/server/auth/checkIfAuthed";
+import { hasAnyFeatureAnywhereServer } from "@/lib/server/auth/checkIfAuthed";
 import { query } from "@/lib/server/db/external/internalQuery";
 import type { RawFortSearchEntry } from "@/lib/services/search.svelte";
 import { checkFeatureInBounds } from "@/lib/services/user/checkPerm";
+import { Features } from "@/lib/utils/features";
 import { getLogger } from "@/lib/utils/logger";
 import { error, json } from "@sveltejs/kit";
 
 const log = getLogger("fortsearch");
 
 export async function POST({ request, locals }) {
-	let hasPokestops = hasFeatureAnywhereServer(locals.perms, MapObjectType.POKESTOP, locals.user);
-	let hasGyms = hasFeatureAnywhereServer(locals.perms, MapObjectType.GYM, locals.user);
+	let hasPokestops = hasAnyFeatureAnywhereServer(locals.perms, [Features.POKESTOP], locals.user);
+	let hasGyms = hasAnyFeatureAnywhereServer(locals.perms, [Features.GYM], locals.user);
 	if (!hasPokestops && !hasGyms) error(401);
 
 	const bounds = (await request.json()) as Bounds;
 
-	const pokestopPermitted = checkFeatureInBounds(locals.perms, MapObjectType.POKESTOP, bounds);
-	const gymPermitted = checkFeatureInBounds(locals.perms, MapObjectType.GYM, bounds);
+	const pokestopPermitted = checkFeatureInBounds(locals.perms, Features.POKESTOP, bounds);
+	const gymPermitted = checkFeatureInBounds(locals.perms, Features.GYM, bounds);
 
 	const queries = [];
 	let values: any[] = [];

--- a/src/routes/api/wayfarer/forts/+server.ts
+++ b/src/routes/api/wayfarer/forts/+server.ts
@@ -1,8 +1,8 @@
-import { MapObjectType } from "@/lib/mapObjects/mapObjectTypes";
 import { buildSpatialFilter } from "@/lib/server/api/spatialFilter";
 import { hasFeatureAnywhereServer } from "@/lib/server/auth/checkIfAuthed";
 import { query } from "@/lib/server/db/external/internalQuery";
 import { checkFeatureInBounds } from "@/lib/services/user/checkPerm";
+import { Features } from "@/lib/utils/features";
 import { getLogger } from "@/lib/utils/logger";
 import { error, json } from "@sveltejs/kit";
 import { geojson, s2 } from "s2js";
@@ -25,9 +25,7 @@ export type WayfarerFortsResponse = {
 };
 
 export async function POST({ request, locals }) {
-	const hasPokestops = hasFeatureAnywhereServer(locals.perms, MapObjectType.POKESTOP, locals.user);
-	const hasGyms = hasFeatureAnywhereServer(locals.perms, MapObjectType.GYM, locals.user);
-	if (!hasPokestops && !hasGyms) error(401);
+	if (!hasFeatureAnywhereServer(locals.perms, Features.WAYFARER_MAP, locals.user)) error(401);
 
 	let body: WayfarerFortsRequest;
 	try {
@@ -73,30 +71,28 @@ export async function POST({ request, locals }) {
 
 	const bounds = { minLat, maxLat, minLon, maxLon };
 
-	const pokestopPermitted = checkFeatureInBounds(locals.perms, MapObjectType.POKESTOP, bounds);
-	const gymPermitted = checkFeatureInBounds(locals.perms, MapObjectType.GYM, bounds);
+	// Governed solely by the `wayfarer_map` feature; pokestop/gym grants don't affect it.
+	const permitted = checkFeatureInBounds(locals.perms, Features.WAYFARER_MAP, bounds);
 
 	const queries: string[] = [];
 	const values: unknown[] = [];
 
-	if (hasPokestops && pokestopPermitted) {
-		const spatial = buildSpatialFilter(pokestopPermitted.polygon ?? null, pokestopPermitted.bounds);
+	if (permitted) {
+		const pokestopSpatial = buildSpatialFilter(permitted.polygon ?? null, permitted.bounds);
 		queries.push(
 			"(SELECT 'p' AS type, id, lat, lon, name, url, description, partner_id, sponsor_id, updated, first_seen_timestamp FROM pokestop WHERE " +
-				spatial.sql +
+				pokestopSpatial.sql +
 				" AND deleted = 0)"
 		);
-		values.push(...spatial.values);
-	}
+		values.push(...pokestopSpatial.values);
 
-	if (hasGyms && gymPermitted) {
-		const spatial = buildSpatialFilter(gymPermitted.polygon ?? null, gymPermitted.bounds);
+		const gymSpatial = buildSpatialFilter(permitted.polygon ?? null, permitted.bounds);
 		queries.push(
 			"(SELECT 'g' AS type, id, lat, lon, name, url, description, partner_id, sponsor_id, updated, first_seen_timestamp FROM gym WHERE " +
-				spatial.sql +
+				gymSpatial.sql +
 				" AND deleted = 0)"
 		);
-		values.push(...spatial.values);
+		values.push(...gymSpatial.values);
 	}
 
 	if (queries.length === 0) error(401);


### PR DESCRIPTION
closes #137 
closes #126 

this reworks the permission system and allows configuring access to features at a much finer level.

Breaking changes! Previously `pokestop`, `gym`, `pokemon` and `station` gave access to the entire feature families. You have to use `<name>*` instead, now.

here's the extract from the docs:

Feature keys are granular. The bare family keys are the **narrow** grant; the `*`-suffixed
key grants the whole family, and `*` grants everything. Umbrella wildcards group several
features together (e.g. `map_object*`, `tool*`). Data you are not permitted to see is never
sent by the server, and features you cannot access are hidden in the UI (including the search
index and the search box itself).

:::caution[Breaking change]
`pokemon`, `pokestop`, `gym`, and `station` previously granted the **entire** family. They
now grant only the narrow subset (basic pokemon / plain pokestop / plain gym / plain station).
Use the `*`-suffixed wildcard (`pokemon*`, `pokestop*`, `gym*`, `station*`) to restore the old
"whole family" behaviour. Configs using `*` are unaffected.
:::

Supported feature keys:

- `*` — everything
- **Pokemon:** `pokemon` (basic — no iv/pvp/cp/level), `pokemon_iv` (iv/cp/level), `pokemon_pvp` (full — iv + pvp), `pokemon*`
- **Pokestops:** `pokestop` (plain), `quest`, `invasion`, `lure`, `contest`, `kecleon`, `golden_pokestop`, `pokestop*`
- **Gyms:** `gym` (plain), `raid`, `gym*`
- **Stations:** `station` (plain), `max_battle`, `station*`
- **Other map objects:** `nest`, `tappable`, `s2cell`, `spawnpoint`, `route`
- **Tools:** `scout`, `coverage_map`, `wayfarer_map`
- **UI:** `search`, `weather`

Umbrella wildcards bundle several of the above:

- `map_object*` — every map object (`pokemon*`, `pokestop*`, `gym*`, `station*` and all minor map objects)
- `minor_map_object*` — map objects with no sub-features (`nest`, `tappable`, `s2cell`, `spawnpoint`, `route`)
- `tool*` — `scout`, `coverage_map`, `wayfarer_map`
- `ui*` — `search`, `weather`