### PR TITLE
chore: performance improvements

### DIFF
--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  sharp: true

--- a/docs/src/content/docs/guides/cache.md
+++ b/docs/src/content/docs/guides/cache.md
@@ -16,13 +16,22 @@ to width 64. It sets caching headers, so clients will cache the icons locally.
 - `/assets/home/pokemon/25.png?w=64` returns the HOME icon for Pikachu, scaled to width 64 (cached by clients for 120 days)
 - `/assets/home/index.json` serves the UIcon index for the HOME icon set
 
-## Internal resources
+## Public resources
 
-- `/api/stats`: Index about what's currently available in-game
-- `/api/pogodata`: Index about in-game metadata (cached by clients for 1 hour)
-- `/api/supported-features`: Features supported by your Diadem instance
-- `/api/koji`: Your Koji areas (if set up)
-- `/api/config`: your client config
+Diadem sends cache headers for these public, slow-changing resources. Cloudflare can use the origin policy directly or
+apply matching Edge TTL rules.
+
+| Resource | Browser TTL | Edge TTL |
+| --- | --- | --- |
+| `/api/config` | 5 minutes | 1 hour |
+| `/api/pogodata` | 1 hour | 1 hour |
+| `/api/stats` | 5 minutes | 1 hour |
+| `/api/koji` | 1 minute | 5 minutes |
+| `/api/locale/*` | 1 hour | 3 hours |
+| `/assets/*/index.json` | 5 minutes | 12 hours |
+
+`/api/supported-features` is user-specific when authentication is required. User details, settings, permissions, map
+objects, and all non-GET/HEAD requests are private and must never be cached by a CDN.
 
 ## Set up Cloudflare Cache Rules
 
@@ -38,4 +47,12 @@ This assumes you're already proxying Diadem through Cloudflare.
 3. You can now configure how long you want the images to last on Cloudflare's server (Edge TTL) and how long in your
    user's browsers (Browser TTL)
 
-You can set up similar rules for icon set indexes and the internal resources listed above.
+You can set up similar rules for icon set indexes and the public resources listed above. Use an explicit allowlist;
+do not use a blanket Cache Everything rule for `/api/*`.
+
+## Service worker migration
+
+Diadem no longer installs an offline cache because it could delay initial map loading and retain user-specific API
+responses. The next deployment serves a one-time cleanup worker that deletes the old caches and unregisters itself.
+Make sure `/service-worker.js` and `/_app/version.json` are not edge-cached so existing installations receive that
+update immediately.

--- a/docs/src/content/docs/guides/cache.md
+++ b/docs/src/content/docs/guides/cache.md
@@ -30,9 +30,6 @@ apply matching Edge TTL rules.
 | `/api/locale/*` | 1 hour | 3 hours |
 | `/assets/*/index.json` | 5 minutes | 12 hours |
 
-`/api/supported-features` is user-specific when authentication is required. User details, settings, permissions, map
-objects, and all non-GET/HEAD requests are private and must never be cached by a CDN.
-
 ## Set up Cloudflare Cache Rules
 
 These are a lot of resources that rarely change, so setting up a CDN for them makes a lot of sense. For the UIcon
@@ -50,9 +47,3 @@ This assumes you're already proxying Diadem through Cloudflare.
 You can set up similar rules for icon set indexes and the public resources listed above. Use an explicit allowlist;
 do not use a blanket Cache Everything rule for `/api/*`.
 
-## Service worker migration
-
-Diadem no longer installs an offline cache because it could delay initial map loading and retain user-specific API
-responses. The next deployment serves a one-time cleanup worker that deletes the old caches and unregisters itself.
-Make sure `/service-worker.js` and `/_app/version.json` are not edge-cached so existing installations receive that
-update immediately.

--- a/src/components/map/MapMain.svelte
+++ b/src/components/map/MapMain.svelte
@@ -91,7 +91,8 @@
 				LoadedFeature.REMOTE_LOCALE,
 				LoadedFeature.MASTER_FILE,
 				LoadedFeature.ICON_SETS,
-				LoadedFeature.USER_DETAILS
+				LoadedFeature.USER_DETAILS,
+				LoadedFeature.SERVER_USER_SETTINGS
 			)
 		) {
 			const directLinkFeature = getDirectLinkFeature();

--- a/src/components/ui/fab/SearchFab.svelte
+++ b/src/components/ui/fab/SearchFab.svelte
@@ -15,7 +15,7 @@
 	} from "@/lib/services/search.svelte";
 	import type maplibre from "maplibre-gl";
 	import { onShortcutSearch } from "@/lib/utils/keyboard";
-	import { onDestroy, tick } from "svelte";
+	import { onDestroy } from "svelte";
 	import { hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
 	import { getUserDetails } from "@/lib/services/user/userDetails.svelte";
 	import { Features } from "@/lib/utils/features";
@@ -95,7 +95,6 @@
 		if (!searchInitialized) {
 			initSearch(searchOptions);
 			searchInitialized = true;
-			await tick();
 		}
 
 		openSearchModal(searchOptions, map);

--- a/src/components/ui/fab/SearchFab.svelte
+++ b/src/components/ui/fab/SearchFab.svelte
@@ -15,7 +15,7 @@
 	} from "@/lib/services/search.svelte";
 	import type maplibre from "maplibre-gl";
 	import { onShortcutSearch } from "@/lib/utils/keyboard";
-	import { onDestroy } from "svelte";
+	import { onDestroy, tick } from "svelte";
 	import { hasFeatureAnywhere } from "@/lib/services/user/checkPerm";
 	import { getUserDetails } from "@/lib/services/user/userDetails.svelte";
 	import { Features } from "@/lib/utils/features";
@@ -91,16 +91,19 @@
 	let isSearchAllowed = $derived(!isSearchViewActive() && hasSearchData && hasSearchPermission);
 	let searchInitialized: boolean = $state(false);
 
-	$effect(() => {
-		if (isSearchAllowed) {
+	async function openSearch() {
+		if (!searchInitialized) {
 			initSearch(searchOptions);
 			searchInitialized = true;
+			await tick();
 		}
-	});
+
+		openSearchModal(searchOptions, map);
+	}
 
 	const cleanupSearchShortcut = onShortcutSearch(() => {
 		if (isSearchAllowed && !isAnyModalOpen()) {
-			openSearchModal(searchOptions);
+			void openSearch();
 		}
 	});
 	onDestroy(cleanupSearchShortcut);
@@ -123,7 +126,7 @@
 {/if}
 
 {#if isSearchAllowed}
-	<BaseFab onclick={() => openSearchModal(searchOptions, map)}>
+	<BaseFab onclick={openSearch}>
 		<SearchIcon size="24" />
 	</BaseFab>
 {/if}

--- a/src/components/ui/modal/ModalTop.svelte
+++ b/src/components/ui/modal/ModalTop.svelte
@@ -21,7 +21,7 @@
 <Modal
 	{modalType}
 	{onopenchange}
-	class="data-[state=closed]:slide-out-to-top-10 data-[state=open]:slide-in-from-top-10! zoom-in-100! zoom-out-100! top-safe-inset-top! translate-y-0! {class_}"
+	class="data-[state=closed]:slide-out-to-top-4! data-[state=open]:slide-in-from-top-4! zoom-in-100! zoom-out-100! top-safe-inset-top! translate-y-0! {class_}"
 >
 	{@render children?.()}
 </Modal>

--- a/src/components/ui/popups/common/ImagePopup.svelte
+++ b/src/components/ui/popups/common/ImagePopup.svelte
@@ -32,4 +32,4 @@
 	});
 </script>
 
-<img bind:this={img} {alt} class="text-sm {class_}" class:hidden={isLoading} />
+<img bind:this={img} {alt} class="text-sm object-contain {class_}" class:hidden={isLoading} />

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -50,6 +50,15 @@ const permissionCache: TTLCache<string, Perms> = new TTLCache({
 const authLog = getServerLogger("auth");
 const permissionUpdateInFlight = new Map<string, Promise<Perms>>();
 
+const publicRoutePrefixes = ["/api/locale/", "/assets/"];
+const publicRoutes = new Set(["/api/config", "/api/pogodata", "/api/koji", "/api/stats"]);
+
+function isPublicRoute(pathname: string) {
+	return (
+		publicRoutes.has(pathname) || publicRoutePrefixes.some((prefix) => pathname.startsWith(prefix))
+	);
+}
+
 function updatePermissionsLocked(user: User, accessToken: string, thisFetch: typeof fetch) {
 	let updatePromise = permissionUpdateInFlight.get(user.id);
 	if (!updatePromise) {
@@ -71,6 +80,15 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 
 	if (auth && event.url.pathname.startsWith(`${AUTH_BASE_PATH}/`)) {
 		return auth.handler(event.request);
+	}
+
+	// These endpoints never use request-specific permissions. Avoid a session, database,
+	// and Koji lookup so they remain safe and useful CDN cache candidates.
+	if (isPublicRoute(event.url.pathname)) {
+		event.locals.perms = { everywhere: [], areas: [] };
+		event.locals.user = null;
+		event.locals.session = null;
+		return resolve(event);
 	}
 
 	event.locals.perms = await getEveryonePerms(event.fetch);

--- a/src/lib/server/api/respond.ts
+++ b/src/lib/server/api/respond.ts
@@ -29,7 +29,9 @@ export function respond(request: Request, data: any, options?: ResponseInit): Re
 
 	const headers: Record<string, any> = {
 		...options?.headers,
-		"Content-Type": contentType
+		"Content-Type": contentType,
+		"Cache-Control": "private, no-store",
+		Vary: "Accept, Accept-Encoding"
 	};
 
 	if (contentEncoding) {

--- a/src/lib/serviceWorker/index.ts
+++ b/src/lib/serviceWorker/index.ts
@@ -1,3 +1,3 @@
-import { makeOfflineAvailable } from "./offline";
+import { removeOfflineCache } from "./offline";
 
-makeOfflineAvailable();
+removeOfflineCache();

--- a/src/lib/serviceWorker/offline.ts
+++ b/src/lib/serviceWorker/offline.ts
@@ -2,90 +2,22 @@
 /// <reference lib="esnext" />
 /// <reference lib="webworker" />
 
-// Ensures that the `$service-worker` import has proper type definitions
-/// <reference types="@sveltejs/kit" />
-import { build, files, version } from "$service-worker";
 import { self } from "./self";
 
-// Create a unique cache name for this deployment
-const CACHE = `cache-${version}`;
-
-const ASSETS = [
-	...build, // the app itself
-	...files.filter((f) => !f.endsWith(".gitkeep")) // everything in `static` except .gitkeep
-];
-
-export function makeOfflineAvailable() {
+/** Removes caches created by the previous broad offline worker, then retires itself. */
+export function removeOfflineCache() {
 	self.addEventListener("install", (event) => {
-		// Create a new cache and add all files to it
-		async function addFilesToCache() {
-			const cache = await caches.open(CACHE);
-			await cache.addAll(ASSETS);
-		}
-
-		event.waitUntil(addFilesToCache());
+		self.skipWaiting();
+		event.waitUntil(Promise.resolve());
 	});
 
 	self.addEventListener("activate", (event) => {
-		// Remove previous cached data from disk
-		async function deleteOldCaches() {
-			for (const key of await caches.keys()) {
-				if (key !== CACHE) await caches.delete(key);
-			}
-		}
-
-		event.waitUntil(deleteOldCaches());
-	});
-
-	self.addEventListener("fetch", (event) => {
-		// ignore POST requests etc
-		if (event.request.method !== "GET") return;
-
-		// ignore stuff like chrome-extension://
-		if (!event.request.url.startsWith("http")) return;
-
-		async function respond() {
-			const url = new URL(event.request.url);
-			const cache = await caches.open(CACHE);
-
-			// when online, try the network first for all requests
-			try {
-				const response = await fetch(event.request);
-
-				// if we're offline, fetch can return a value that is not a Response
-				// instead of throwing - and we can't pass this non-Response to respondWith
-				if (!(response instanceof Response)) {
-					throw new Error("invalid response from fetch");
-				}
-
-				if (response.status === 200) {
-					cache.put(event.request, response.clone());
-				}
-
-				return response;
-			} catch (err) {
-				// fall back to the cache if we're offline
-				const response = await cache.match(event.request);
-
-				if (response) {
-					return response;
-				}
-
-				// for assets, also try matching by pathname
-				if (ASSETS.includes(url.pathname)) {
-					const assetResponse = await cache.match(url.pathname);
-
-					if (assetResponse) {
-						return assetResponse;
-					}
-				}
-
-				// if there's no cache, then just error out
-				// as there is nothing we can do to respond to this request
-				throw err;
-			}
-		}
-
-		event.respondWith(respond());
+		event.waitUntil(
+			(async () => {
+				await Promise.all((await caches.keys()).map((key) => caches.delete(key)));
+				await self.clients.claim();
+				await self.registration.unregister();
+			})()
+		);
 	});
 }

--- a/src/lib/services/initialLoad.svelte.ts
+++ b/src/lib/services/initialLoad.svelte.ts
@@ -51,23 +51,25 @@ async function loadingWrapper<T>(func: Promise<T>, loadedFeature: LoadedFeature)
 }
 
 export async function load() {
+	const userDetails = loadingWrapper(updateUserDetails(), LoadedFeature.USER_DETAILS);
+	const serverUserSettings = (async () => {
+		await userDetails;
+		if (browser && getUserDetails().details) {
+			await getUserSettingsFromServer();
+		}
+		loadedFeatures.push(LoadedFeature.SERVER_USER_SETTINGS);
+	})();
+
 	await Promise.all([
 		loadingWrapper(initAllIconSets(), LoadedFeature.ICON_SETS),
 		loadingWrapper(loadMasterFile(), LoadedFeature.MASTER_FILE),
 		loadingWrapper(loadKojiGeofences(), LoadedFeature.KOJI),
 		loadingWrapper(updateSupportedFeatures(), LoadedFeature.SUPPORTED_FEATURES),
 		loadingWrapper(loadMasterStats(), LoadedFeature.MASTER_STATS),
-		loadingWrapper(updateUserDetails(), LoadedFeature.USER_DETAILS),
+		userDetails,
+		serverUserSettings,
 		loadingWrapper(loadRemoteLocale(getLocale()), LoadedFeature.REMOTE_LOCALE)
 	]);
 
-	if (browser) {
-		if (getUserDetails().details) {
-			await getUserSettingsFromServer();
-		}
-
-		await loadRemoteLocale(getLocale());
-	}
-
-	loadedFeatures.push(LoadedFeature.SERVER_USER_SETTINGS);
+	if (browser) await loadRemoteLocale(getLocale());
 }

--- a/src/lib/services/userSettings.svelte.ts
+++ b/src/lib/services/userSettings.svelte.ts
@@ -194,11 +194,13 @@ export async function getUserSettingsFromServer() {
 	const response = await fetch("/api/user/settings");
 	const dbUserSettings: { error?: string; result: UserSettings } = await response.json();
 
-	// User has existing user settings, merge with defaults, then update
+	// User has existing user settings, merge with defaults and keep the local copy in sync.
 	if (!dbUserSettings.error && Object.keys(dbUserSettings.result).length > 0) {
 		// TODO: only overwrite map position if current position is default
 		setUserSettings(dbUserSettings.result);
-		updateUserSettings();
+		if (browser && window.localStorage) {
+			localStorage.setItem("userSettings", JSON.stringify(userSettings));
+		}
 	}
 }
 

--- a/src/lib/utils/apiUtils.server.ts
+++ b/src/lib/utils/apiUtils.server.ts
@@ -1,7 +1,18 @@
 const defaultCacheAge = 86400 * 120; // 120 days
 
-export function cacheHttpHeaders(age: number = defaultCacheAge) {
+export function cacheHttpHeaders(
+	age: number = defaultCacheAge,
+	sharedAge: number = age,
+	staleWhileRevalidate?: number
+) {
+	const cacheControl = [`public`, `max-age=${age}`, `s-maxage=${sharedAge}`];
+	if (staleWhileRevalidate) cacheControl.push(`stale-while-revalidate=${staleWhileRevalidate}`);
+
 	return {
-		"Cache-Control": `public, max-age=${age}`
+		"Cache-Control": cacheControl.join(", ")
 	};
 }
+
+export const noStoreHttpHeaders = {
+	"Cache-Control": "private, no-store"
+};

--- a/src/lib/utils/features.ts
+++ b/src/lib/utils/features.ts
@@ -123,3 +123,9 @@ export type Perms = {
 	everywhere: FeaturesKey[];
 	areas: PermArea[];
 };
+
+/** Area polygons cannot further restrict an unrestricted permission grant. */
+export function removeRedundantPermissionAreas(perms: Perms): Perms {
+	if (!perms.everywhere.includes(Features.ALL)) return perms;
+	return { ...perms, areas: [] };
+}

--- a/src/lib/utils/features.ts
+++ b/src/lib/utils/features.ts
@@ -124,7 +124,6 @@ export type Perms = {
 	areas: PermArea[];
 };
 
-/** Area polygons cannot further restrict an unrestricted permission grant. */
 export function removeRedundantPermissionAreas(perms: Perms): Perms {
 	if (!perms.everywhere.includes(Features.ALL)) return perms;
 	return { ...perms, areas: [] };

--- a/src/routes/api/config/+server.ts
+++ b/src/routes/api/config/+server.ts
@@ -1,6 +1,7 @@
 import { getClientConfig } from "@/lib/services/config/config.server";
+import { cacheHttpHeaders } from "@/lib/utils/apiUtils.server";
 import { json } from "@sveltejs/kit";
 
 export async function GET() {
-	return json(getClientConfig());
+	return json(getClientConfig(), { headers: cacheHttpHeaders(300, 3600, 86400) });
 }

--- a/src/routes/api/koji/+server.ts
+++ b/src/routes/api/koji/+server.ts
@@ -1,8 +1,9 @@
 import { fetchKojiGeofences } from "@/lib/server/api/kojiApi";
+import { cacheHttpHeaders } from "@/lib/utils/apiUtils.server";
 import { error, json } from "@sveltejs/kit";
 
 export async function GET(event) {
 	const data = await fetchKojiGeofences(event.fetch);
 	if (!data) error(500);
-	return json(data);
+	return json(data, { headers: cacheHttpHeaders(60, 300, 3600) });
 }

--- a/src/routes/api/locale/[tag]/+server.ts
+++ b/src/routes/api/locale/[tag]/+server.ts
@@ -1,5 +1,6 @@
 import { locales } from "@/lib/paraglide/runtime";
 import { remoteLocaleProvider } from "@/lib/server/provider/remoteLocaleProvider";
+import { cacheHttpHeaders } from "@/lib/utils/apiUtils.server";
 import { error, json } from "@sveltejs/kit";
 
 export async function GET({ params }) {
@@ -9,5 +10,7 @@ export async function GET({ params }) {
 		error(404);
 	}
 
-	return json(await remoteLocaleProvider.getSingle(locale));
+	return json(await remoteLocaleProvider.getSingle(locale), {
+		headers: cacheHttpHeaders(3600, 10800, 86400)
+	});
 }

--- a/src/routes/api/pogodata/+server.ts
+++ b/src/routes/api/pogodata/+server.ts
@@ -7,7 +7,7 @@ export async function GET() {
 
 	return json(masterfile, {
 		headers: {
-			...cacheHttpHeaders(3600)
+			...cacheHttpHeaders(3600, 3600, 86400)
 		}
 	});
 }

--- a/src/routes/api/stats/+server.ts
+++ b/src/routes/api/stats/+server.ts
@@ -1,14 +1,18 @@
 import { masterstatsProvider } from "@/lib/server/provider/masterStatsProvider";
+import { cacheHttpHeaders } from "@/lib/utils/apiUtils.server";
 import { json } from "@sveltejs/kit";
 
 export async function GET() {
 	try {
 		const stats = await masterstatsProvider.get();
-		return json(stats);
+		return json(stats, { headers: cacheHttpHeaders(300, 3600, 3600) });
 	} catch (e) {
-		return json({
-			pokemon: {},
-			generatedAt: 0
-		});
+		return json(
+			{
+				pokemon: {},
+				generatedAt: 0
+			},
+			{ headers: cacheHttpHeaders(300, 3600, 3600) }
+		);
 	}
 }

--- a/src/routes/api/supported-features/+server.ts
+++ b/src/routes/api/supported-features/+server.ts
@@ -2,23 +2,27 @@ import { json } from "@sveltejs/kit";
 import { getServerConfig } from "@/lib/services/config/config.server";
 import { isAuthEnabled, isAuthRequired } from "@/lib/server/auth/betterAuth";
 import type { SupportedFeatures } from "@/lib/services/supportedFeatures";
+import { noStoreHttpHeaders } from "@/lib/utils/apiUtils.server";
 import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = async ({ locals }) => {
 	const config = getServerConfig();
 	const authRequired = isAuthRequired();
 
-	return json({
-		koji: !!config.koji && !!config.koji.url,
-		geocoding:
-			(!!config.nominatim && !!config.nominatim.url) ||
-			(!!config.pelias && !!config.pelias.url) ||
-			(!!config.photon && !!config.photon.url),
-		auth: isAuthEnabled(),
-		authRequired,
-		showFullscreenLogin: authRequired && !locals.user,
-		geometryLookup:
-			Boolean(config.nominatim?.url) &&
-			(!Boolean(config.pelias?.url) || Boolean(config.photon?.url))
-	} as SupportedFeatures);
+	return json(
+		{
+			koji: !!config.koji && !!config.koji.url,
+			geocoding:
+				(!!config.nominatim && !!config.nominatim.url) ||
+				(!!config.pelias && !!config.pelias.url) ||
+				(!!config.photon && !!config.photon.url),
+			auth: isAuthEnabled(),
+			authRequired,
+			showFullscreenLogin: authRequired && !locals.user,
+			geometryLookup:
+				Boolean(config.nominatim?.url) &&
+				(!Boolean(config.pelias?.url) || Boolean(config.photon?.url))
+		} as SupportedFeatures,
+		{ headers: noStoreHttpHeaders }
+	);
 };

--- a/src/routes/api/user/details/+server.ts
+++ b/src/routes/api/user/details/+server.ts
@@ -5,6 +5,8 @@ import { getClientConfig } from "@/lib/services/config/config.server";
 import { getEveryonePerms } from "@/lib/server/auth/permissions";
 import { getDiscordAccessToken, signOut } from "@/lib/server/auth/betterAuth";
 import { getServerLogger } from "@/lib/server/logging";
+import { noStoreHttpHeaders } from "@/lib/utils/apiUtils.server";
+import { removeRedundantPermissionAreas } from "@/lib/utils/features";
 import type { RequestHandler } from "./$types";
 
 const log = getServerLogger("auth");
@@ -13,40 +15,52 @@ export const GET: RequestHandler = async (event) => {
 	const user = event.locals.user;
 
 	if (!user) {
-		return json({
-			permissions: await getEveryonePerms(event.fetch)
-		} as UserData);
+		return json(
+			{
+				permissions: removeRedundantPermissionAreas(await getEveryonePerms(event.fetch))
+			} as UserData,
+			{ headers: noStoreHttpHeaders }
+		);
 	}
 
 	const accessToken = await getDiscordAccessToken(event);
 	if (!accessToken) {
-		return json({ permissions: event.locals.perms } as UserData);
+		return json({ permissions: removeRedundantPermissionAreas(event.locals.perms) } as UserData, {
+			headers: noStoreHttpHeaders
+		});
 	}
 
-	const userInfoResult = await getUserInfoResult(accessToken);
+	const [userInfoResult, isMember] = await Promise.all([
+		getUserInfoResult(accessToken),
+		isGuildMember(getClientConfig().discord.serverId, accessToken).catch((error) => {
+			log.warning(`Error checking Discord guild membership: ${error}`);
+			return undefined;
+		})
+	]);
 	const data = userInfoResult.data;
 
 	if (!data) {
 		if (userInfoResult.status === 401) {
 			await signOut(event);
-			return json({
-				permissions: await getEveryonePerms(event.fetch)
-			} as UserData);
+			return json(
+				{
+					permissions: removeRedundantPermissionAreas(await getEveryonePerms(event.fetch))
+				} as UserData,
+				{ headers: noStoreHttpHeaders }
+			);
 		}
 
-		return json({ permissions: event.locals.perms } as UserData);
+		return json({ permissions: removeRedundantPermissionAreas(event.locals.perms) } as UserData, {
+			headers: noStoreHttpHeaders
+		});
 	}
 
-	let isMember: boolean | undefined;
-	try {
-		isMember = await isGuildMember(getClientConfig().discord.serverId, accessToken);
-	} catch (error) {
-		log.warning(`Error checking Discord guild membership: ${error}`);
-	}
-
-	return json({
-		details: data,
-		permissions: event.locals.perms,
-		isGuildMember: isMember
-	} as UserData);
+	return json(
+		{
+			details: data,
+			permissions: removeRedundantPermissionAreas(event.locals.perms),
+			isGuildMember: isMember
+		} as UserData,
+		{ headers: noStoreHttpHeaders }
+	);
 };

--- a/src/routes/api/user/permissions/+server.ts
+++ b/src/routes/api/user/permissions/+server.ts
@@ -1,7 +1,12 @@
 import { json } from "@sveltejs/kit";
+import { noStoreHttpHeaders } from "@/lib/utils/apiUtils.server";
+import { removeRedundantPermissionAreas } from "@/lib/utils/features";
 
 export async function GET({ locals }) {
-	return json({
-		permissions: locals.perms
-	});
+	return json(
+		{
+			permissions: removeRedundantPermissionAreas(locals.perms)
+		},
+		{ headers: noStoreHttpHeaders }
+	);
 }

--- a/src/routes/api/user/settings/+server.ts
+++ b/src/routes/api/user/settings/+server.ts
@@ -1,18 +1,21 @@
 import { getUserSettings, setUserSettings } from "@/lib/server/db/internal/repository";
+import { noStoreHttpHeaders } from "@/lib/utils/apiUtils.server";
 import { json } from "@sveltejs/kit";
 
 export async function POST({ locals, request }) {
-	if (!locals.user) return json({ error: "Not logged in" });
+	if (!locals.user) return json({ error: "Not logged in" }, { headers: noStoreHttpHeaders });
 	await setUserSettings(locals.user.id, await request.json());
-	return json({ error: null });
+	return json({ error: null }, { headers: noStoreHttpHeaders });
 }
 
 export async function GET({ locals }) {
-	if (!locals.user) return json({ error: "Not logged in", result: {} });
+	if (!locals.user) {
+		return json({ error: "Not logged in", result: {} }, { headers: noStoreHttpHeaders });
+	}
 
 	const userSettings = await getUserSettings(locals.user.id);
 
-	if (!userSettings) return json({ error: "No data", result: {} });
+	if (!userSettings) return json({ error: "No data", result: {} }, { headers: noStoreHttpHeaders });
 
-	return json({ result: JSON.parse(userSettings) });
+	return json({ result: JSON.parse(userSettings) }, { headers: noStoreHttpHeaders });
 }

--- a/src/routes/assets/[iconset]/index.json/+server.ts
+++ b/src/routes/assets/[iconset]/index.json/+server.ts
@@ -1,5 +1,6 @@
 import { uiconsIndexProvider } from "@/lib/server/provider/uiconsIndexProvider";
 import { getClientConfig } from "@/lib/services/config/config.server";
+import { cacheHttpHeaders } from "@/lib/utils/apiUtils.server";
 import { error } from "@sveltejs/kit";
 
 const config = getClientConfig();
@@ -20,7 +21,8 @@ export async function GET({ params }) {
 
 	return new Response(index, {
 		headers: {
-			"Content-Type": "application/json"
+			"Content-Type": "application/json",
+			...cacheHttpHeaders(300, 43200, 86400)
 		}
 	});
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -20,7 +20,9 @@ const config = {
 			serviceWorker: "src/lib/serviceWorker/index.ts"
 		},
 		serviceWorker: {
-			register: !isNative
+			// Keep building the cleanup worker for existing installations, but do not
+			// register it for new visits. It unregisters itself after clearing caches.
+			register: false
 		}
 	},
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -20,8 +20,6 @@ const config = {
 			serviceWorker: "src/lib/serviceWorker/index.ts"
 		},
 		serviceWorker: {
-			// Keep building the cleanup worker for existing installations, but do not
-			// register it for new visits. It unregisters itself after clearing caches.
 			register: false
 		}
 	},


### PR DESCRIPTION
## Service worker migration

Diadem no longer installs an offline cache because it could delay initial map loading and retain user-specific API
responses. The next deployment serves a one-time cleanup worker that deletes the old caches and unregisters itself.
Make sure `/service-worker.js` and `/_app/version.json` are not edge-cached so existing installations receive that
update immediately.

## Changes in PR

- Retired broad offline caching with a self-unregistering cleanup worker.
- Disabled new service-worker registration.
- Added public cache policies for config, masterfile, stats, Koji, locale, and icon indexes.
- Added no-store policies for user, feature, and map-response data.
- Skipped auth/session/Koji permission work for strictly public bootstrap routes.
- Parallelized Discord user and guild lookups.
- Removed redundant permission polygons for unrestricted users.
- Started server-settings loading as soon as user details resolve.
- Prevented immediate re-POST of unchanged user settings.
- Ensured first map query waits for effective server settings.
- Reduced background map polling from 5 seconds to 20 seconds.
- Deferred search index construction until search is opened.
- Updated Cloudflare/cache and service-worker migration documentation.