### PR TITLE
chore: handle overlays nicer

### DIFF
--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  esbuild: true
-  sharp: true

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -4,9 +4,14 @@ import type { AvailableLanguageTag } from "../../lib/paraglide/runtime";
 import type { Perms } from "@/lib/utils/features";
 import type { BetterAuthSessionData } from "@/lib/server/auth/betterAuth";
 import type { User } from "@/lib/server/db/internal/schema";
+import type { OverlayEntry } from "@/lib/ui/overlays.svelte";
 
 declare global {
 	namespace App {
+		interface PageState {
+			overlays?: OverlayEntry[];
+		}
+
 		interface Locals {
 			paraglide: ParaglideLocals<AvailableLanguageTag>;
 			user: User | null;

--- a/src/components/menus/mobile/MobileMenuCoverageMap.svelte
+++ b/src/components/menus/mobile/MobileMenuCoverageMap.svelte
@@ -43,7 +43,7 @@
 				<Drawer.Popup
 					class="drawer-popup rounded-t-xl flex flex-col px-2 py-2 w-full h-full border border-t-border bg-card/60 backdrop-blur-sm pb-[env(safe-area-inset-bottom)]"
 				>
-					<div class="w-10 mx-auto mb-2 rounded-full bg-ring h-1 shrink-0"></div>
+					<Drawer.Handle class="mb-1" />
 					<Drawer.Content
 						class="{contentClass} min-h-0 flex-1 bg-background rounded-lg border border-border"
 					>

--- a/src/components/menus/mobile/MobileMenuMain.svelte
+++ b/src/components/menus/mobile/MobileMenuMain.svelte
@@ -38,10 +38,10 @@
 	<Drawer.Portal>
 		<Drawer.Viewport class="z-20 drawer-viewport">
 			<Drawer.Popup
-				class="drawer-popup {contentClass} flex flex-col px-2 pt-2 w-full h-full border border-t-border bg-card/60 backdrop-blur-sm pb-[env(safe-area-inset-bottom)]"
+				class="drawer-popup {contentClass} flex flex-col w-full h-full pb-[env(safe-area-inset-bottom)]"
 			>
 				<MobileTitle />
-				<Drawer.Content class="pb-20 content min-h-0 flex-1">
+				<Drawer.Content class="pb-20 content min-h-0 flex-1 px-2 bg-card/60 backdrop-blur-sm pt-3">
 					<MenuContainer />
 				</Drawer.Content>
 			</Drawer.Popup>

--- a/src/components/menus/mobile/MobileMenuStatic.svelte
+++ b/src/components/menus/mobile/MobileMenuStatic.svelte
@@ -30,10 +30,10 @@
 	<Drawer.Portal>
 		<Drawer.Viewport class="drawer-viewport flex items-end z-0!">
 			<Drawer.Popup
-				class="drawer-popup flex flex-col px-2 pt-2 w-full h-fit border border-t-border bg-card/60 backdrop-blur-sm rounded-t-xl pb-[env(safe-area-inset-bottom)]"
+				class="drawer-popup flex flex-col w-full h-fit rounded-t-xl pb-[env(safe-area-inset-bottom)]"
 			>
 				<MobileTitle />
-				<Drawer.Content class="pb-20 content">
+				<Drawer.Content class="pb-20 content px-2 bg-card/60 backdrop-blur-sm pt-3">
 					<MenuContainer />
 				</Drawer.Content>
 			</Drawer.Popup>

--- a/src/components/menus/mobile/MobileTitle.svelte
+++ b/src/components/menus/mobile/MobileTitle.svelte
@@ -3,17 +3,35 @@
 	import CloseButton from "@/components/ui/CloseButton.svelte";
 	import { Drawer } from "$lib/drawer";
 	import { mAny } from "@/lib/utils/anyMessage";
+	import * as m from "$lib/paraglide/messages";
+	import { closePopup } from "$lib/mapObjects/interact";
+	import { X } from "@lucide/svelte";
+	import Button from "@/components/ui/input/Button.svelte";
 </script>
 
-<div class="sticky top-2 z-20 mb-2">
+<div class="sticky top-2 z-20">
 	<div
-		class="w-full py-1 flex items-center justify-between bg-card rounded-lg border border-border"
+		class="w-full bg-card rounded-t-xl rounded-b-sm border border-border relative"
 	>
-		<Drawer.Title level={1} class="font-bold text-base tracking-tight mx-4">
-			{#if getOpenedMenu()}
-				{mAny("nav_" + getOpenedMenu())}
-			{/if}
-		</Drawer.Title>
-		<CloseButton onclick={closeMenu} class="mr-1 hover:bg-accent/90! active:bg-accent/90!" />
+		<Drawer.Handle />
+
+		<Button
+			variant="ghost"
+			size=""
+			class="rounded-full p-2 size-9 bg-accent/50 absolute right-3 top-1/2 -translate-y-1/2"
+			title={m.close()}
+			onclick={closeMenu}
+		>
+			<X class="size-4.5" />
+		</Button>
+
+		<div class="flex items-center justify-between pb-4 -mt-2">
+			<Drawer.Title level={1} class="font-bold text-base tracking-tight mx-6">
+				{#if getOpenedMenu()}
+					{mAny("nav_" + getOpenedMenu())}
+				{/if}
+			</Drawer.Title>
+
+		</div>
 	</div>
 </div>

--- a/src/components/ui/fab/SearchFab.svelte
+++ b/src/components/ui/fab/SearchFab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isAnyModalOpen } from "@/lib/ui/modal.svelte.js";
+	import { isAnyModalOpen, isOpenModal } from "@/lib/ui/modal.svelte.js";
 	import Search from "@/components/ui/search/Search.svelte";
 	import BaseFab from "@/components/ui/fab/BaseFab.svelte";
 	import { Search as SearchIcon } from "@lucide/svelte";
@@ -120,7 +120,7 @@
 	<WayfarerSearchResults {results} {map} />
 {/snippet}
 
-{#if searchInitialized}
+{#if searchInitialized || isOpenModal("search")}
 	<Search {searchOptions} />
 {/if}
 

--- a/src/components/ui/popups/common/FortDetailsModal.svelte
+++ b/src/components/ui/popups/common/FortDetailsModal.svelte
@@ -57,7 +57,7 @@
 	onopenchange={(open) => {
 		if (!open) restoreExpandedDrawerSnapPoint();
 	}}
-	class="z-50"
+	class="z-60"
 >
 	{#if fortDetails}
 		<Card

--- a/src/components/ui/popups/common/PopupBaseDrawer.svelte
+++ b/src/components/ui/popups/common/PopupBaseDrawer.svelte
@@ -97,7 +97,7 @@
 				bind:ref={popupElement}
 				class="drawer-popup flex flex-col w-full h-full rounded-t-xl border border-t-border bg-card pb-[env(safe-area-inset-bottom)] mt-safe-inset-top"
 			>
-				<div class="w-10 mx-auto my-3 rounded-full bg-ring h-1 shrink-0"></div>
+				<Drawer.Handle class="my-1" />
 				<Drawer.Content class="flex min-h-0 flex-1 flex-col overflow-hidden">
 					<PopupBaseStatic {coords} {data} {props} onlyShowNavigationButton={snapPoint === 1} />
 				</Drawer.Content>

--- a/src/components/ui/popups/common/PopupButton.svelte
+++ b/src/components/ui/popups/common/PopupButton.svelte
@@ -4,7 +4,14 @@
 	import type { LucideIcon } from "@/lib/types/lucide";
 	import { DropdownMenu } from "bits-ui";
 	import { fly, slide } from "svelte/transition";
+	import { onDestroy } from "svelte";
 	import type { PopupActionDropdown } from "@/lib/ui/popupActions";
+	import {
+		closeOverlay,
+		isReconcilingOverlays,
+		openOverlay,
+		registerOverlayHandler
+	} from "@/lib/ui/overlays.svelte";
 
 	let {
 		Icon,
@@ -22,6 +29,20 @@
 		labelActive?: string;
 		actions?: PopupActionDropdown[];
 	} & ButtonProps = $props();
+
+	const overlayId = $props.id();
+	let dropdownOpen = $state(false);
+	const unregisterOverlayHandler = registerOverlayHandler("popup-actions", (entries) => {
+		dropdownOpen = entries.some((entry) => entry.id === overlayId);
+	});
+	onDestroy(unregisterOverlayHandler);
+
+	function setDropdownOpen(open: boolean) {
+		dropdownOpen = open;
+		if (isReconcilingOverlays()) return;
+		if (open) openOverlay({ kind: "popup-actions", id: overlayId });
+		else closeOverlay({ kind: "popup-actions", id: overlayId });
+	}
 </script>
 
 <div class="flex gap-0.5 [&>*:first-child:not(:last-child)]:rounded-r-none" role="group">
@@ -36,7 +57,7 @@
 	</Button>
 
 	{#if actions.length}
-		<DropdownMenu.Root>
+		<DropdownMenu.Root bind:open={dropdownOpen} onOpenChange={setDropdownOpen}>
 			<DropdownMenu.Trigger>
 				{#snippet child({ props })}
 					<Button class="px-3! rounded-l-none" size="default" variant="secondary" {...props}>
@@ -56,7 +77,7 @@
 					{#if open}
 						<div {...wrapperProps}>
 							<div {...props} transition:fly={{ y: 6, duration: 90 }}>
-								{#each actions as action}
+								{#each actions as action (action.label)}
 									{@const Icon = action.Icon}
 									<DropdownMenu.Item
 										class="data-highlighted:bg-muted cursor-pointer rounded-md px-3 h-9 flex font-medium text-sm items-center gap-2"

--- a/src/components/ui/popups/common/PopupButton.svelte
+++ b/src/components/ui/popups/common/PopupButton.svelte
@@ -3,15 +3,10 @@
 	import { Circle, CircleCheck, Ellipsis } from "@lucide/svelte";
 	import type { LucideIcon } from "@/lib/types/lucide";
 	import { DropdownMenu } from "bits-ui";
-	import { fly, slide } from "svelte/transition";
+	import { fly } from "svelte/transition";
 	import { onDestroy } from "svelte";
 	import type { PopupActionDropdown } from "@/lib/ui/popupActions";
-	import {
-		closeOverlay,
-		isReconcilingOverlays,
-		openOverlay,
-		registerOverlayHandler
-	} from "@/lib/ui/overlays.svelte";
+	import { closeOverlay, isReconcilingOverlays, openOverlay, registerOverlayHandler } from "@/lib/ui/overlays.svelte";
 
 	let {
 		Icon,

--- a/src/components/ui/search/ActiveSearchView.svelte
+++ b/src/components/ui/search/ActiveSearchView.svelte
@@ -1,23 +1,14 @@
 <script lang="ts">
 	import { Search, X } from "@lucide/svelte";
 	import Button from "@/components/ui/input/Button.svelte";
-	import { getActiveSearch, resetActiveSearchFilter } from "@/lib/features/activeSearch.svelte.js";
+	import { getActiveSearch } from "@/lib/features/activeSearch.svelte.js";
 	import { m } from "@/lib/paraglide/messages";
-	import { closeSearchModal } from "@/lib/ui/modal.svelte";
-	import { slide } from "svelte/transition";
-
-	function onkeydown(e: KeyboardEvent) {
-		if (e.key === "Escape") {
-			resetActiveSearchFilter();
-		}
-	}
+	import { closeOverlay } from "@/lib/ui/overlays.svelte";
 </script>
-
-<svelte:window {onkeydown} />
 
 <button
 	class="w-full max-w-2xl! mx-auto flex items-center gap-4 pointer-events-auto rounded-lg border bg-card text-card-foreground shadow-md cursor-pointer text-left"
-	onclick={resetActiveSearchFilter}
+	onclick={() => closeOverlay({ kind: "active-search", id: "banner" })}
 >
 	<Search size="18" class="ml-4 shrink-0" />
 	<span class="my-4">
@@ -28,9 +19,9 @@
 		class="ml-auto mr-2"
 		variant="ghost"
 		size="icon"
-		onclick={() => {
-			resetActiveSearchFilter();
-			closeSearchModal();
+		onclick={(e) => {
+			e.stopPropagation();
+			closeOverlay({ kind: "active-search", id: "banner" });
 		}}
 	>
 		<X size="20" />

--- a/src/components/ui/search/Search.svelte
+++ b/src/components/ui/search/Search.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { onMount } from "svelte";
-	import { MapPin, Nut, Search, Spotlight, Squirrel, TextCursor, X } from "@lucide/svelte";
+	import { MapPin, Nut, Search, Spotlight, Squirrel, X } from "@lucide/svelte";
 	import * as m from "@/lib/paraglide/messages";
 	import { closeSearchModal } from "@/lib/ui/modal.svelte.js";
+	import { getActiveSearch } from "@/lib/features/activeSearch.svelte.js";
 	import Button from "@/components/ui/input/Button.svelte";
 	import ModalTop from "@/components/ui/modal/ModalTop.svelte";
 	import {
@@ -11,10 +12,8 @@
 		getCurrentSearchResults,
 		getIsSearchingAddress,
 		search,
-		SearchableType,
 		type SearchOptions,
-		setCurrentSearchQuery,
-		shouldSearchType
+		setCurrentSearchQuery
 	} from "@/lib/services/search.svelte";
 	import { isSupportedFeature } from "@/lib/services/supportedFeatures";
 	import { getUserSettings } from "@/lib/services/userSettings.svelte";
@@ -46,7 +45,9 @@
 <ModalTop
 	class="w-[calc(100%-1rem)]! max-w-2xl!"
 	modalType="search"
-	onopenchange={() => setCurrentSearchQuery("")}
+	onopenchange={(open) => {
+		if (!open && !getActiveSearch()) setCurrentSearchQuery("");
+	}}
 >
 	<Command.Root
 		class="rounded-lg bg-card text-card-foreground max-h-[calc(100vh-1rem)] overflow-hidden"

--- a/src/lib/drawer/Handle.svelte
+++ b/src/lib/drawer/Handle.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import type { HTMLButtonAttributes } from "svelte/elements";
+	import { getDrawerContext } from "./context.svelte.js";
+
+	let { class: class_ = "", ...props }: HTMLButtonAttributes = $props();
+	const state = getDrawerContext();
+
+	function toggleSnapPoint() {
+		const snapPoints = state.options.getSnapPoints();
+		if (!snapPoints || snapPoints.length < 2) return;
+
+		const currentIndex = Math.max(
+			0,
+			snapPoints.findIndex((point) => Object.is(point, state.snapPoint))
+		);
+		state.changeSnapPoint(snapPoints[(currentIndex + 1) % snapPoints.length]);
+	}
+</script>
+
+<button
+	type="button"
+	aria-label="Toggle drawer size"
+	aria-expanded={state.snapPoint === state.options.getSnapPoints()?.at(-1)}
+	class="mx-auto flex h-7 w-12 shrink-0 cursor-pointer items-center justify-center rounded-full touch-none {class_}"
+	{...props}
+	onclick={toggleSnapPoint}
+>
+	<span class="h-1 w-10 rounded-full bg-ring"></span>
+</button>

--- a/src/lib/drawer/Handle.svelte
+++ b/src/lib/drawer/Handle.svelte
@@ -5,9 +5,11 @@
 	let { class: class_ = "", ...props }: HTMLButtonAttributes = $props();
 	const state = getDrawerContext();
 
+	const snapPoints = $derived(state.options.getSnapPoints());
+	const isTogglable = $derived((snapPoints?.length ?? 0) >= 2);
+
 	function toggleSnapPoint() {
-		const snapPoints = state.options.getSnapPoints();
-		if (!snapPoints || snapPoints.length < 2) return;
+		if (!isTogglable) return;
 
 		const currentIndex = Math.max(
 			0,
@@ -19,9 +21,11 @@
 
 <button
 	type="button"
+	disabled={!isTogglable}
 	aria-label="Toggle drawer size"
-	aria-expanded={state.snapPoint === state.options.getSnapPoints()?.at(-1)}
-	class="mx-auto flex h-7 w-12 shrink-0 cursor-pointer items-center justify-center rounded-full touch-none {class_}"
+	aria-expanded={state.snapPoint === snapPoints?.at(-1)}
+	class="mx-auto flex h-7 w-12 shrink-0 items-center justify-center rounded-full touch-none {class_}"
+	class:cursor-pointer={isTogglable}
 	{...props}
 	onclick={toggleSnapPoint}
 >

--- a/src/lib/drawer/index.ts
+++ b/src/lib/drawer/index.ts
@@ -4,6 +4,7 @@ import Close from "./Close.svelte";
 import Content from "./Content.svelte";
 import Indent from "./Indent.svelte";
 import IndentBackground from "./IndentBackground.svelte";
+import Handle from "./Handle.svelte";
 import Popup from "./Popup.svelte";
 import Provider from "./Provider.svelte";
 import Root from "./Root.svelte";
@@ -28,6 +29,7 @@ export const Drawer = {
 	SwipeArea,
 	Indent,
 	IndentBackground,
+	Handle,
 	VirtualKeyboardProvider,
 	createHandle
 };

--- a/src/lib/features/activeSearch.svelte.ts
+++ b/src/lib/features/activeSearch.svelte.ts
@@ -16,6 +16,12 @@ import type { ContestFocus, QuestReward } from "@/lib/types/mapObjectData/pokest
 import { getDefaultGymFilter } from "@/lib/utils/gymUtils";
 import { getDefaultPokestopFilter, RewardType } from "@/lib/utils/pokestopUtils";
 import { getDefaultStationFilter } from "@/lib/utils/stationUtils";
+import {
+	closeOverlay,
+	isReconcilingOverlays,
+	openOverlay,
+	registerOverlayHandler
+} from "@/lib/ui/overlays.svelte";
 import { m } from "@/lib/paraglide/messages";
 import { mPokemon } from "$lib/services/ingameLocale";
 
@@ -27,28 +33,9 @@ export type ActiveSearchParams = {
 
 let activeSearchSvelte: ActiveSearchParams | undefined = $state(undefined);
 
-// setActiveSearch({
-// 	name: "Vulpix (Alola)",
-// 	mapObject: MapObjectType.POKEMON,
-// 	filter: {
-// 		category: "pokemon",
-// 		enabled: true,
-// 		filters: [
-// 			{
-// 				id: "searchOverwrite",
-// 				enabled: true,
-// 				title: { message: "unknown_filter" },
-// 				icon: { isUserSelected: false },
-// 				pokemon: [
-// 					{
-// 						pokemon_id: 37,
-// 						form: 56
-// 					}
-// 				]
-// 			}
-// 		]
-// 	} as FilterPokemon
-// });
+registerOverlayHandler("active-search", (entries) => {
+	if (entries.length === 0 && activeSearchSvelte) resetActiveSearchFilter();
+});
 
 export function getActiveSearch() {
 	return activeSearchSvelte;
@@ -62,11 +49,13 @@ export function setActiveSearch(newParams: ActiveSearchParams) {
 	activeSearchSvelte = newParams;
 	deleteAllFeatures();
 	updateAllMapObjects().then();
+	if (!isReconcilingOverlays()) openOverlay({ kind: "active-search", id: "banner" });
 }
 
 export function clearActiveSearchFilter() {
 	activeSearchSvelte = undefined;
 	deleteAllFeatures();
+	if (!isReconcilingOverlays()) closeOverlay({ kind: "active-search", id: "banner" });
 }
 
 export function resetActiveSearchFilter() {
@@ -74,9 +63,7 @@ export function resetActiveSearchFilter() {
 	updateAllMapObjects().then();
 }
 
-export function setActiveSearchPokemon(
-	pokemon: { pokemon_id: number; form?: number }
-) {
+export function setActiveSearchPokemon(pokemon: { pokemon_id: number; form?: number }) {
 	setActiveSearch({
 		name: mPokemon(pokemon),
 		mapObject: MapObjectType.POKEMON,

--- a/src/lib/features/coverageMap.svelte.ts
+++ b/src/lib/features/coverageMap.svelte.ts
@@ -2,7 +2,6 @@ import { goto } from "$app/navigation";
 import { getKojiGeofences, type KojiFeature } from "@/lib/features/koji";
 import { CoverageMapLayerId } from "@/lib/map/layers";
 import { hasLoadedFeature, LoadedFeature } from "@/lib/services/initialLoad.svelte";
-import { Menu, openMenu } from "@/lib/ui/menus.svelte";
 import { getFeatureJump } from "@/lib/utils/geo";
 import { featureCollection } from "@turf/turf";
 import type { Feature, FeatureCollection, Polygon } from "geojson";

--- a/src/lib/features/coverageMap.svelte.ts
+++ b/src/lib/features/coverageMap.svelte.ts
@@ -2,11 +2,19 @@ import { goto } from "$app/navigation";
 import { getKojiGeofences, type KojiFeature } from "@/lib/features/koji";
 import { CoverageMapLayerId } from "@/lib/map/layers";
 import { hasLoadedFeature, LoadedFeature } from "@/lib/services/initialLoad.svelte";
-import { Menu, openMenu, setJustChangedMenus } from "@/lib/ui/menus.svelte";
+import { Menu, openMenu } from "@/lib/ui/menus.svelte";
 import { getFeatureJump } from "@/lib/utils/geo";
 import { featureCollection } from "@turf/turf";
 import type { Feature, FeatureCollection, Polygon } from "geojson";
 import maplibre from "maplibre-gl";
+import {
+	clearOverlays,
+	closeOverlay,
+	getOverlayPayload,
+	isReconcilingOverlays,
+	openOverlay,
+	registerOverlayHandler
+} from "@/lib/ui/overlays.svelte";
 
 type CoverageMapAreaFeature = Feature<Polygon, CoverageMapAreaProperties>;
 export type CoverageMapAreaProperties = {
@@ -21,6 +29,10 @@ let clickedAreas: KojiFeature[] | undefined = $state(undefined);
 let coverageMap: maplibre.Map | undefined = $state(undefined);
 let invokedFromMap: boolean = $state(false);
 
+registerOverlayHandler("coverage-popup", (entries) => {
+	clickedAreas = getOverlayPayload<KojiFeature[]>(entries.at(-1));
+});
+
 export function coverageMapClickHandler(event: maplibre.MapMouseEvent) {
 	if (event.originalEvent.defaultPrevented) return;
 
@@ -31,17 +43,18 @@ export function coverageMapClickHandler(event: maplibre.MapMouseEvent) {
 		layers: [CoverageMapLayerId.POLYGON_FILL]
 	}) as CoverageMapAreaFeature[];
 
-	if (areas.length === 0) {
-		clickedAreas = undefined;
-	} else {
-		clickedAreas = [...new Map(areas.map((x) => [x.properties.id, x])).values()];
-	}
+	setClickedCoverageMapAreas([...new Map(areas.map((x) => [x.properties.id, x])).values()]);
 }
 
 export function openCoverageMap() {
+	clearOverlays();
+	const navigation = goto("/coverage");
+	prepareOpenCoverageMap();
+	return navigation;
+}
+
+export function prepareOpenCoverageMap() {
 	invokedFromMap = true;
-	setJustChangedMenus();
-	goto("/coverage").then();
 }
 
 export function getCoverageMapAreas(): FeatureCollection<Polygon, CoverageMapAreaProperties> {
@@ -75,8 +88,11 @@ export function getClickedCoverageMapAreas() {
 	return clickedAreas;
 }
 
-export function setClickedCoverageMapAreas(features: KojiFeature[]) {
-	clickedAreas = features;
+export function setClickedCoverageMapAreas(features: KojiFeature[] | undefined) {
+	clickedAreas = features?.length ? features : undefined;
+	if (isReconcilingOverlays()) return;
+	if (clickedAreas) openOverlay({ kind: "coverage-popup", id: "areas", data: clickedAreas });
+	else closeOverlay({ kind: "coverage-popup", id: "areas" });
 }
 
 export function selectCoverageMapArea(area: KojiFeature) {

--- a/src/lib/features/coverageMap.svelte.ts
+++ b/src/lib/features/coverageMap.svelte.ts
@@ -62,7 +62,7 @@ export function getCoverageMapAreas(): FeatureCollection<Polygon, CoverageMapAre
 		const fillColor = styles.getPropertyValue("--coverage-polygon-stroke");
 		const strokeColor = styles.getPropertyValue("--coverage-polygon-fill");
 		return featureCollection(
-			getKojiGeofences().map((g, i) => {
+			getKojiGeofences().map((g) => {
 				return {
 					...g,
 					id: "koji-" + g.properties.id,

--- a/src/lib/features/wayfarerMap.svelte.ts
+++ b/src/lib/features/wayfarerMap.svelte.ts
@@ -4,10 +4,18 @@ import { featureCollection } from "@turf/turf";
 import type { Feature, FeatureCollection, Point, Polygon } from "geojson";
 import maplibre from "maplibre-gl";
 import { geojson, s2 } from "s2js";
-import { closeMenu, setJustChangedMenus } from "@/lib/ui/menus.svelte";
 import { getCoveringS2Cells } from "@/lib/mapObjects/s2cells";
 import type { MapStyle } from "@/lib/services/config/configTypes";
 import { getMapStyle } from "@/lib/utils/mapStyle";
+import {
+	clearOverlays,
+	closeOverlay,
+	getOverlayPayload,
+	isReconcilingOverlays,
+	openOverlay,
+	registerOverlayHandler,
+	replaceOverlay
+} from "@/lib/ui/overlays.svelte";
 
 const MAX_S2_CELLS = 5000;
 export const WAYFARER_CELLS_14_MIN_ZOOM = 10;
@@ -45,6 +53,20 @@ let clickedL14Cell:
 let invokedFromMap: boolean = $state(false);
 let style: MapStyle | undefined = $state(undefined);
 
+registerOverlayHandler("wayfarer-popup", (entries) => {
+	const entry = entries.at(-1);
+	if (entry?.id === "fort") {
+		clickedFort = getOverlayPayload<FortData>(entry);
+		clickedL14Cell = undefined;
+	} else if (entry?.id === "cell") {
+		clickedL14Cell = getOverlayPayload<typeof clickedL14Cell>(entry);
+		clickedFort = undefined;
+	} else {
+		clickedFort = undefined;
+		clickedL14Cell = undefined;
+	}
+});
+
 export function getWayfarerStyle() {
 	return style ? getMapStyle(style) : undefined;
 }
@@ -68,6 +90,9 @@ export function getClickedL14Cell() {
 export function setClickedFort(fort: FortData | undefined) {
 	clickedFort = fort;
 	clickedL14Cell = undefined;
+	if (isReconcilingOverlays()) return;
+	if (fort) replaceOverlay({ kind: "wayfarer-popup", id: "fort", data: fort });
+	else closeOverlay({ kind: "wayfarer-popup", id: "fort" });
 }
 
 export function setClickedL14Cell(
@@ -77,11 +102,15 @@ export function setClickedL14Cell(
 ) {
 	clickedL14Cell = cell;
 	clickedFort = undefined;
+	if (isReconcilingOverlays()) return;
+	if (cell) replaceOverlay({ kind: "wayfarer-popup", id: "cell", data: cell });
+	else closeOverlay({ kind: "wayfarer-popup", id: "cell" });
 }
 
 export function clearClicked() {
 	clickedFort = undefined;
 	clickedL14Cell = undefined;
+	if (!isReconcilingOverlays()) closeOverlay({ kind: "wayfarer-popup", id: "" });
 }
 
 function buildFetchKey(cellIds: string[], countsOnly: boolean): string {
@@ -444,9 +473,14 @@ export function wayfarerMapClickHandler(event: maplibre.MapMouseEvent) {
 }
 
 export function openWayfarerMap() {
-	closeMenu();
+	clearOverlays();
+	const navigation = goto("/wayfarer");
+	prepareOpenWayfarerMap();
+	return navigation;
+}
+
+export function prepareOpenWayfarerMap() {
 	invokedFromMap = true;
-	goto("/wayfarer").then();
 }
 
 export function getWayfarerInvokedFromMap() {

--- a/src/lib/features/wayfarerMap.svelte.ts
+++ b/src/lib/features/wayfarerMap.svelte.ts
@@ -12,7 +12,6 @@ import {
 	closeOverlay,
 	getOverlayPayload,
 	isReconcilingOverlays,
-	openOverlay,
 	registerOverlayHandler,
 	replaceOverlay
 } from "@/lib/ui/overlays.svelte";

--- a/src/lib/map/mapPositionParams.svelte.ts
+++ b/src/lib/map/mapPositionParams.svelte.ts
@@ -1,10 +1,10 @@
-import { replaceState } from "$app/navigation";
 import { Coords } from "@/lib/utils/coordinates";
 import maplibre from "maplibre-gl";
 import { setMap } from "@/lib/map/map.svelte.js";
 import { onMapDragStart, onMapMoveEnd, onMapMoveStart, onTouchStart } from "@/lib/map/events";
 import { clearPressTimer, onContextMenu } from "@/lib/ui/contextmenu.svelte.js";
 import { getUserSettings, updateUserSettings } from "@/lib/services/userSettings.svelte.js";
+import { replacePageState } from "@/lib/ui/overlays.svelte";
 
 export function getMapPositionFromUrlParams(): [Coords | undefined, number | undefined] {
 	let zoom: number | undefined = undefined;
@@ -29,7 +29,7 @@ export function getMapPositionFromUrlParams(): [Coords | undefined, number | und
 
 export function clearMapPositionUrlParams() {
 	if (!window.location.search) return;
-	replaceState(window.location.origin + window.location.pathname, {});
+	replacePageState(window.location.origin + window.location.pathname);
 }
 
 export function getInitialMapPositionMain() {

--- a/src/lib/map/mapPositionParams.svelte.ts
+++ b/src/lib/map/mapPositionParams.svelte.ts
@@ -1,8 +1,4 @@
 import { Coords } from "@/lib/utils/coordinates";
-import maplibre from "maplibre-gl";
-import { setMap } from "@/lib/map/map.svelte.js";
-import { onMapDragStart, onMapMoveEnd, onMapMoveStart, onTouchStart } from "@/lib/map/events";
-import { clearPressTimer, onContextMenu } from "@/lib/ui/contextmenu.svelte.js";
 import { getUserSettings, updateUserSettings } from "@/lib/services/userSettings.svelte.js";
 import { replacePageState } from "@/lib/ui/overlays.svelte";
 

--- a/src/lib/mapObjects/interact.ts
+++ b/src/lib/mapObjects/interact.ts
@@ -1,4 +1,3 @@
-import { replaceState } from "$app/navigation";
 import { page } from "$app/state";
 import { setCurrentScoutCenter } from "@/lib/features/scout.svelte";
 import { MapObjectLayerId } from "@/lib/map/layers";
@@ -16,10 +15,23 @@ import { closeMenu, getOpenedMenu, Menu } from "@/lib/ui/menus.svelte";
 import { Coords } from "@/lib/utils/coordinates";
 import { getMapPath } from "@/lib/utils/getMapPath";
 import type { MapMouseEvent } from "maplibre-gl";
+import {
+	closeOverlay,
+	getOverlayPayload,
+	openOverlay,
+	replacePageState,
+	registerOverlayHandler
+} from "@/lib/ui/overlays.svelte";
+
+registerOverlayHandler("map-popup", (entries) => {
+	const entry = entries.at(-1);
+	const selection = getOverlayPayload<{ data: MapData; isOverwrite: boolean }>(entry);
+	setCurrentSelectedData(selection?.data ?? null, selection?.isOverwrite ?? false);
+});
 
 export function closePopup() {
 	setCurrentSelectedData(null);
-	setCurrentPath();
+	if (!closeOverlay({ kind: "map-popup", id: "selected" }, getCurrentPath())) setCurrentPath();
 
 	// call this to remove selected data (if needed)
 	updateAllMapObjects(true, true).then();
@@ -27,7 +39,7 @@ export function closePopup() {
 
 export function openPopup(data: MapData, isOverwrite: boolean = false) {
 	setCurrentSelectedData(data, isOverwrite);
-	setCurrentPath();
+	openOverlay({ kind: "map-popup", id: "selected", data: { data, isOverwrite } }, getCurrentPath());
 }
 
 export function updateCurrentPath() {
@@ -51,7 +63,7 @@ export function getCurrentPath(options: { data?: MapData } | undefined = undefin
 }
 
 function setCurrentPath() {
-	replaceState(getCurrentPath(), {});
+	replacePageState(getCurrentPath());
 }
 
 export function clickMapHandler(event: MapMouseEvent) {

--- a/src/lib/ui/contextmenu.svelte.ts
+++ b/src/lib/ui/contextmenu.svelte.ts
@@ -2,6 +2,12 @@ import { setCurrentScoutCenter } from "@/lib/features/scout.svelte.js";
 import { getOpenedMenu, Menu } from "@/lib/ui/menus.svelte.js";
 import { Coords } from "@/lib/utils/coordinates";
 import maplibre from "maplibre-gl";
+import {
+	closeOverlay,
+	isReconcilingOverlays,
+	openOverlay,
+	registerOverlayHandler
+} from "@/lib/ui/overlays.svelte";
 
 export let pressTimer: NodeJS.Timeout[] = [];
 export const longPressDuration = 500;
@@ -10,12 +16,19 @@ let isContextMenuOpen: boolean = $state(false);
 let contextMenuEvent: maplibre.MapTouchEvent | maplibre.MapMouseEvent | undefined =
 	$state(undefined);
 
+registerOverlayHandler("context-menu", (entries) => {
+	isContextMenuOpen = entries.length > 0;
+});
+
 export function getIsContextMenuOpen() {
 	return isContextMenuOpen;
 }
 
 export function setIsContextMenuOpen(state: boolean) {
 	isContextMenuOpen = state;
+	if (isReconcilingOverlays()) return;
+	if (state) openOverlay({ kind: "context-menu", id: "map" });
+	else closeOverlay({ kind: "context-menu", id: "map" });
 }
 
 export function getContextMenuEvent() {

--- a/src/lib/ui/menus.svelte.ts
+++ b/src/lib/ui/menus.svelte.ts
@@ -1,5 +1,13 @@
 import { isAllowedTwoSidebars } from "$lib/utils/device";
 import { setCurrentSelectedData } from "$lib/mapObjects/currentSelectedState.svelte";
+import { getConfig } from "$lib/services/config/config";
+import { getMapPath } from "$lib/utils/getMapPath";
+import {
+	closeOverlay,
+	isReconcilingOverlays,
+	registerOverlayHandler,
+	replaceOverlay
+} from "$lib/ui/overlays.svelte";
 
 export enum Menu {
 	PROFILE = "profile",
@@ -10,19 +18,36 @@ export enum Menu {
 }
 
 let openedMenu: Menu | null = $state(null);
+let persistentMenu: Menu | null = null;
 
 // set this when switching from tool menu to tool,
 let justChangedMenus: boolean = $state(false);
 
-export function openMenu(type: Menu) {
+registerOverlayHandler("menu", (entries) => {
+	const entry = entries.at(-1);
+	openedMenu = entry ? (entry.id as Menu) : persistentMenu;
+});
+
+export function openMenu(type: Menu, history = true) {
+	persistentMenu = history ? null : type;
 	openedMenu = type;
 	if (!isAllowedTwoSidebars()) {
-		setCurrentSelectedData(null)
+		setCurrentSelectedData(null);
+	}
+	if (history && !isReconcilingOverlays()) {
+		const replaceKinds = isAllowedTwoSidebars() ? undefined : (["menu", "map-popup"] as const);
+		replaceOverlay(
+			{ kind: "menu", id: type },
+			replaceKinds ? getMapPath(getConfig()) : "",
+			replaceKinds ? [...replaceKinds] : undefined
+		);
 	}
 }
 
-export function closeMenu() {
+export function closeMenu({ history = true }: { history?: boolean } = {}) {
+	if (!history) persistentMenu = null;
 	openedMenu = null;
+	if (history && !isReconcilingOverlays()) closeOverlay({ kind: "menu", id: "" });
 }
 
 export function getOpenedMenu() {

--- a/src/lib/ui/modal.svelte.ts
+++ b/src/lib/ui/modal.svelte.ts
@@ -5,6 +5,12 @@ import {
 } from "@/lib/map/mapObjectsInterval";
 import { setCurrentSearchQuery } from "@/lib/services/search.svelte";
 import type { Snippet } from "svelte";
+import {
+	closeOverlay,
+	isReconcilingOverlays,
+	openOverlay,
+	registerOverlayHandler
+} from "@/lib/ui/overlays.svelte";
 
 export type OpenModals = {
 	search: boolean;
@@ -35,9 +41,23 @@ let openModals: OpenModals = $state({
 
 let selectOptions: Snippet | undefined = $state(undefined);
 
+registerOverlayHandler("modal", (entries) => {
+	for (const modal of Object.keys(openModals) as ModalType[]) {
+		openModals[modal] = entries.some((entry) => entry.id === modal);
+	}
+	if (!openModals.select) selectOptions = undefined;
+	updateMapObjectsInterval();
+});
+
+function updateMapObjectsInterval() {
+	if (isAnyModalOpen()) clearUpdateMapObjectsInterval();
+	else resetUpdateMapObjectsInterval();
+}
+
 export function openModal(modal: ModalType) {
 	openModals[modal] = true;
-	clearUpdateMapObjectsInterval();
+	if (!isReconcilingOverlays()) openOverlay({ kind: "modal", id: modal });
+	updateMapObjectsInterval();
 }
 
 export function openSelectModal(options: Snippet) {
@@ -47,11 +67,9 @@ export function openSelectModal(options: Snippet) {
 
 export function closeModal(modal: ModalType) {
 	openModals[modal] = false;
-	selectOptions = undefined;
-
-	if (!isAnyModalOpen()) {
-		resetUpdateMapObjectsInterval();
-	}
+	if (modal === "select") selectOptions = undefined;
+	if (!isReconcilingOverlays()) closeOverlay({ kind: "modal", id: modal });
+	updateMapObjectsInterval();
 }
 
 export function isOpenModal(modal: ModalType) {

--- a/src/lib/ui/overlays.svelte.ts
+++ b/src/lib/ui/overlays.svelte.ts
@@ -8,7 +8,8 @@ export type OverlayKind =
 	| "context-menu"
 	| "popup-actions"
 	| "coverage-popup"
-	| "wayfarer-popup";
+	| "wayfarer-popup"
+	| "active-search";
 
 export type OverlayEntry = {
 	kind: OverlayKind;

--- a/src/lib/ui/overlays.svelte.ts
+++ b/src/lib/ui/overlays.svelte.ts
@@ -1,0 +1,139 @@
+import { pushState, replaceState } from "$app/navigation";
+import { page } from "$app/state";
+
+export type OverlayKind =
+	| "menu"
+	| "modal"
+	| "map-popup"
+	| "context-menu"
+	| "popup-actions"
+	| "coverage-popup"
+	| "wayfarer-popup";
+
+export type OverlayEntry = {
+	kind: OverlayKind;
+	id: string;
+	payloadKey?: string;
+};
+
+export type OverlayInput = Omit<OverlayEntry, "payloadKey"> & { data?: unknown };
+
+type OverlayHandler = (entries: OverlayEntry[]) => void;
+
+const handlers = new Map<OverlayKind, Set<OverlayHandler>>();
+const payloads = new Map<string, unknown>();
+let activeOverlays: OverlayEntry[] = $state([]);
+let syncing = false;
+let payloadId = 0;
+
+function getOverlays(state: App.PageState = page.state): OverlayEntry[] {
+	return state.overlays ?? [];
+}
+
+function getState(overlays: OverlayEntry[]): App.PageState {
+	return { ...page.state, overlays };
+}
+
+function isSameOverlay(left: OverlayEntry, right: OverlayEntry) {
+	return left.kind === right.kind && left.id === right.id;
+}
+
+function createEntry(entry: OverlayInput): OverlayEntry {
+	if (entry.data === undefined) return { kind: entry.kind, id: entry.id };
+
+	const payloadKey = `${entry.kind}:${entry.id}:${++payloadId}`;
+	payloads.set(payloadKey, entry.data);
+	return { kind: entry.kind, id: entry.id, payloadKey };
+}
+
+export function getOverlayPayload<T>(entry: OverlayEntry | undefined): T | undefined {
+	return entry?.payloadKey ? (payloads.get(entry.payloadKey) as T | undefined) : undefined;
+}
+
+export function registerOverlayHandler(kind: OverlayKind, handler: OverlayHandler) {
+	const kindHandlers = handlers.get(kind) ?? new Set<OverlayHandler>();
+	kindHandlers.add(handler);
+	handlers.set(kind, kindHandlers);
+	handler(activeOverlays.filter((entry) => entry.kind === kind));
+
+	return () => {
+		kindHandlers.delete(handler);
+		if (kindHandlers.size === 0) handlers.delete(kind);
+	};
+}
+
+export function reconcileOverlays(state: App.PageState) {
+	activeOverlays = getOverlays(state);
+	syncing = true;
+	try {
+		for (const [kind, kindHandlers] of handlers) {
+			const entries = activeOverlays.filter((entry) => entry.kind === kind);
+			for (const handler of kindHandlers) handler(entries);
+		}
+	} finally {
+		syncing = false;
+	}
+}
+
+export function isReconcilingOverlays() {
+	return syncing;
+}
+
+export function openOverlay(input: OverlayInput, url: string | URL = "") {
+	const entry = createEntry(input);
+	const overlays = getOverlays();
+	const index = overlays.findIndex((overlay) => isSameOverlay(overlay, entry));
+
+	if (index !== -1) {
+		const next = [...overlays];
+		next[index] = entry;
+		replaceState(url, getState(next));
+		return;
+	}
+
+	pushState(url, getState([...overlays, entry]));
+}
+
+export function replaceOverlay(
+	input: OverlayInput,
+	url: string | URL = "",
+	replaceKinds: OverlayKind[] = [input.kind]
+) {
+	const entry = createEntry(input);
+	const current = getOverlays();
+	const overlays = current.filter((overlay) => !replaceKinds.includes(overlay.kind));
+	const next = [...overlays, entry];
+	if (overlays.length === current.length) pushState(url, getState(next));
+	else replaceState(url, getState(next));
+}
+
+export function closeOverlay(entry: Pick<OverlayEntry, "kind" | "id">, url: string | URL = "") {
+	const overlays = getOverlays();
+	const index = overlays.findLastIndex(
+		(overlay) => overlay.kind === entry.kind && (!entry.id || overlay.id === entry.id)
+	);
+	if (index === -1) return false;
+
+	if (index === overlays.length - 1) {
+		history.back();
+	} else {
+		replaceState(url, getState(overlays.filter((_, overlayIndex) => overlayIndex !== index)));
+	}
+
+	return true;
+}
+
+export function closeTopOverlay() {
+	const overlay = getOverlays().at(-1);
+	if (!overlay) return false;
+	history.back();
+	return true;
+}
+
+export function replacePageState(url: string | URL) {
+	replaceState(url, getState(getOverlays()));
+}
+
+export function clearOverlays() {
+	replaceState("", getState([]));
+}

--- a/src/routes/(main)/+layout.svelte
+++ b/src/routes/(main)/+layout.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { onMount } from "svelte";
+	import { watch } from "runed";
+	import { page } from "$app/state";
 	import { getIsLoading, load } from "@/lib/services/initialLoad.svelte";
 	import Toast from "@/components/ui/Toast.svelte";
 	import { getIsToastOpen } from "@/lib/ui/toasts.svelte";
@@ -7,11 +9,22 @@
 	import { getSelectOptions } from "@/lib/ui/modal.svelte";
 	import Loading from "@/components/ui/Loading.svelte";
 	import FortDetailsModal from "@/components/ui/popups/common/FortDetailsModal.svelte";
+	import { closeTopOverlay, reconcileOverlays } from "@/lib/ui/overlays.svelte";
 
 	let { data, children } = $props();
 
 	onMount(() => load().then());
+
+	watch(() => page.state, reconcileOverlays);
 </script>
+
+<svelte:document
+	onkeydown={(event) => {
+		if (event.key !== "Escape" || !closeTopOverlay()) return;
+		event.preventDefault();
+		event.stopImmediatePropagation();
+	}}
+/>
 
 {#if getIsToastOpen()}
 	<Toast />

--- a/src/routes/(main)/coverage/+page.svelte
+++ b/src/routes/(main)/coverage/+page.svelte
@@ -25,20 +25,20 @@
 	import { useMetadata } from "@/lib/ui/metadata.svelte";
 
 	let map: maplibre.Map | undefined = $state(undefined);
-	openMenu(Menu.COVERAGE_MAP);
+	openMenu(Menu.COVERAGE_MAP, false);
 	useMetadata(() => ({ title: m.nav_coveragemap() }));
 
 	onMount(async () => {
 		await tick();
 		setMap(undefined);
-		openMenu(Menu.COVERAGE_MAP);
+		openMenu(Menu.COVERAGE_MAP, false);
 		closePopup();
 		setIsContextMenuOpen(false);
 		clearMapPositionUrlParams();
 	});
 
 	onDestroy(() => {
-		closeMenu();
+		closeMenu({ history: false });
 	});
 </script>
 

--- a/src/routes/(main)/wayfarer/+page.svelte
+++ b/src/routes/(main)/wayfarer/+page.svelte
@@ -14,7 +14,10 @@
 	import WayfarerFortPopup from "@/components/menus/wayfarer/WayfarerFortPopup.svelte";
 	import WayfarerCellPopup from "@/components/menus/wayfarer/WayfarerCellPopup.svelte";
 	import WayfarerTitle from "@/components/menus/wayfarer/WayfarerTitle.svelte";
-	import { getWayfarerStyleId, setWayfarerStyle } from "@/lib/features/wayfarerMap.svelte";
+	import {
+		getWayfarerStyleId,
+		setWayfarerStyle
+	} from "@/lib/features/wayfarerMap.svelte";
 
 	let map: maplibre.Map | undefined = $state(undefined);
 


### PR DESCRIPTION
closes #90 

- adds clickable handles to all drawers to toggle between snap points
- browser back navigations and pressing the esc key consistently close overlays (popups, modals, drawers, etc)